### PR TITLE
Manage Users in Identity Store

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.5-42-g1746365
+_commit: v0.0.5-43-gc79bb93
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing Central Infrastructure of an AWS Organization
 python_ci_versions:

--- a/template/.devcontainer/create-aws-profile.sh.jinja
+++ b/template/.devcontainer/create-aws-profile.sh.jinja
@@ -3,25 +3,19 @@ set -ex
 
 mkdir -p ~/.aws
 cat >> ~/.aws/config <<EOF
-[profile central-infra]
+[profile development]
 sso_session = org
 sso_account_id = {% endraw %}{{ aws_development_account_id if use_staging_environment else aws_production_account_id }}{% raw %}
 sso_role_name = LowRiskAccountAdminAccess
-region = us-east-1
-
-[profile identity-center]
-sso_session = org
-sso_account_id = {% endraw %}{{ identity_center_production_account_id }}{% raw %}
-sso_role_name = LowRiskAccountAdminAccess
-region = us-east-1
+region = {% endraw %}{{ aws_org_home_region }}{% raw %}
 
 [sso-session org]
 sso_start_url = https://{% endraw %}{{ aws_identity_center_id }}{% raw %}.awsapps.com/start
-sso_region = us-east-1
+sso_region = {% endraw %}{{ aws_org_home_region }}{% raw %}
 sso_registration_scopes = sso:account:access
 
 [profile localstack]
-region=us-east-1
+region={% endraw %}{{ aws_org_home_region }}{% raw %}
 output=json
 endpoint_url = http://localstack:4566
 EOF

--- a/template/.devcontainer/create-aws-profile.sh.jinja
+++ b/template/.devcontainer/create-aws-profile.sh.jinja
@@ -3,9 +3,15 @@ set -ex
 
 mkdir -p ~/.aws
 cat >> ~/.aws/config <<EOF
-[profile development]
+[profile central-infra]
 sso_session = org
 sso_account_id = {% endraw %}{{ aws_development_account_id if use_staging_environment else aws_production_account_id }}{% raw %}
+sso_role_name = LowRiskAccountAdminAccess
+region = {% endraw %}{{ aws_org_home_region }}{% raw %}
+
+[profile identity-center]
+sso_session = org
+sso_account_id = {% endraw %}{{ identity_center_production_account_id }}{% raw %}
 sso_role_name = LowRiskAccountAdminAccess
 region = {% endraw %}{{ aws_org_home_region }}{% raw %}
 

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib.py
@@ -111,10 +111,11 @@ class User(BaseModel):  # NOT RECOMMENDED TO USE THIS IF YOU HAVE AN EXTERNAL ID
     first_name: str
     last_name: str
     email: str
+    _user: identitystore_classic.User | None = None
 
     @override
     def model_post_init(self, _: Any) -> None:
-        _ = identitystore_classic.User(
+        self._user = identitystore_classic.User(
             f"{self.first_name}-{self.last_name}",
             identity_store_id=ORG_INFO.identity_store_id,
             display_name=f"{self.first_name} {self.last_name}",
@@ -125,3 +126,8 @@ class User(BaseModel):  # NOT RECOMMENDED TO USE THIS IF YOU HAVE AN EXTERNAL ID
             ),
             emails=identitystore_classic.UserEmailsArgs(primary=True, value=self.email),
         )
+
+    @property
+    def user(self) -> identitystore_classic.User:
+        assert self._user is not None
+        return self._user

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib.py
@@ -1,9 +1,47 @@
+from functools import cached_property
+from typing import Any
+from typing import override
+
 from pulumi import ComponentResource
 from pulumi import ResourceOptions
 from pulumi_aws import identitystore as identitystore_classic
 from pulumi_aws import ssoadmin
+from pydantic import BaseModel
 
 from ..iac_management.shared_lib import AwsAccountInfo
+
+
+class OrgInfo(BaseModel):
+    @cached_property
+    def sso_instances(self) -> ssoadmin.AwaitableGetInstancesResult:
+        instances = ssoadmin.get_instances()
+        assert len(instances.arns) == 1, f"Expected a single AWS SSO instance to exist, but found {len(instances.arns)}"
+        return instances
+
+    @cached_property
+    def sso_instance_arn(self) -> str:
+        return self.sso_instances.arns[0]
+
+    @cached_property
+    def identity_store_id(self) -> str:
+        all_ids = self.sso_instances.identity_store_ids
+        assert len(all_ids) == 1, f"Expected a single identity store id, but found {len(all_ids)}"
+        return self.sso_instances.identity_store_ids[0]
+
+
+ORG_INFO = OrgInfo()
+
+
+def lookup_user_id(username: str) -> str:
+    """Convert a username name into an AWS SSO User ID."""
+    return identitystore_classic.get_user(
+        alternate_identifier=identitystore_classic.GetUserAlternateIdentifierArgs(
+            unique_attribute=identitystore_classic.GetUserAlternateIdentifierUniqueAttributeArgs(
+                attribute_path="UserName", attribute_value=username
+            )
+        ),
+        identity_store_id=ORG_INFO.identity_store_id,
+    ).user_id
 
 
 class AwsSsoPermissionSet(ComponentResource):
@@ -15,13 +53,10 @@ class AwsSsoPermissionSet(ComponentResource):
         managed_policies: list[str],
     ):
         super().__init__("labauto:AwsSsoPermissionSet", name, None)
-        sso_instances = ssoadmin.get_instances()
-        assert len(sso_instances.arns) == 1, "Expected a single AWS SSO instance to exist"
-        sso_instance_arn = sso_instances.arns[0]
         self.name = name
         permission_set = ssoadmin.PermissionSet(
             name,
-            instance_arn=sso_instance_arn,
+            instance_arn=ORG_INFO.sso_instance_arn,
             name=name,
             description=description,
             session_duration="PT12H",
@@ -31,7 +66,7 @@ class AwsSsoPermissionSet(ComponentResource):
         for policy_name in managed_policies:
             _ = ssoadmin.ManagedPolicyAttachment(
                 f"{name}-{policy_name}",
-                instance_arn=sso_instance_arn,
+                instance_arn=ORG_INFO.sso_instance_arn,
                 managed_policy_arn=f"arn:aws:iam::aws:policy/{policy_name}",
                 permission_set_arn=self.permission_set_arn,
                 opts=ResourceOptions(parent=self),
@@ -57,31 +92,36 @@ class AwsSsoPermissionSetAccountAssignments(ComponentResource):
             resource_name,
             None,
         )
-        sso_instances = ssoadmin.get_instances()
-        assert len(sso_instances.arns) == 1, "Expected a single AWS SSO instance to exist"
-        sso_instance_arn = sso_instances.arns[0]
-        self.identity_store_id = sso_instances.identity_store_ids[0]
         users = list(set(users))  # Remove any duplicates in the list
 
         for user in users:
             _ = ssoadmin.AccountAssignment(
                 f"{resource_name}-{user}",
-                instance_arn=sso_instance_arn,
+                instance_arn=ORG_INFO.sso_instance_arn,
                 permission_set_arn=permission_set.permission_set_arn,
-                principal_id=self.lookup_user_id(user),
+                principal_id=lookup_user_id(user),
                 principal_type="USER",
                 target_id=account_info.id,
                 target_type="AWS_ACCOUNT",
                 opts=ResourceOptions(parent=self),
             )
 
-    def lookup_user_id(self, name: str) -> str:
-        """Convert a username <first>.<last> name into an AWS SSO User ID."""
-        return identitystore_classic.get_user(
-            alternate_identifier=identitystore_classic.GetUserAlternateIdentifierArgs(
-                unique_attribute=identitystore_classic.GetUserAlternateIdentifierUniqueAttributeArgs(
-                    attribute_path="UserName", attribute_value=name
-                )
+
+class User(BaseModel):  # NOT RECOMMENDED TO USE THIS IF YOU HAVE AN EXTERNAL IDENTITY PROVIDER!!
+    first_name: str
+    last_name: str
+    email: str
+
+    @override
+    def model_post_init(self, _: Any) -> None:
+        _ = identitystore_classic.User(
+            f"{self.first_name}-{self.last_name}",
+            identity_store_id=ORG_INFO.identity_store_id,
+            display_name=f"{self.first_name} {self.last_name}",
+            user_name=f"{self.first_name}.{self.last_name}",
+            name=identitystore_classic.UserNameArgs(
+                given_name=self.first_name,
+                family_name=self.last_name,
             ),
-            identity_store_id=self.identity_store_id,
-        ).user_id
+            emails=identitystore_classic.UserEmailsArgs(primary=True, value=self.email),
+        )

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/program.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/program.py
@@ -20,5 +20,6 @@ def pulumi_program() -> None:
 
     # Create Resources Here
     workloads_dict, _ = load_workload_info()
+    # Note: you must create any new users and deploy them before you can assign any permissions to them (otherwise the Preview will fail)
     create_users()
     create_permissions(workloads_dict)

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/program.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/program.py
@@ -6,6 +6,7 @@ from pulumi import export
 
 from ..iac_management.workload_params import load_workload_info
 from .permissions import create_permissions
+from .users import create_users
 
 logger = logging.getLogger(__name__)
 
@@ -19,4 +20,5 @@ def pulumi_program() -> None:
 
     # Create Resources Here
     workloads_dict, _ = load_workload_info()
+    create_users()
     create_permissions(workloads_dict)

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/users.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/users.py
@@ -1,0 +1,7 @@
+"""Only use this if you do not have an external Identity Provider (e.g. Okta, Microsoft)."""
+
+from .lib import User
+
+
+def create_users():
+    _ = User(first_name="john", last_name="doe", email="john.doe@gmail.com")


### PR DESCRIPTION
 ## Why is this change necessary?
Be able to create users for cases when no external Identity Provider is being used.


 ## How does this change address the issue?
Adds a User pydantic model that creates it


 ## What side effects does this change have?
None


 ## How is this change tested?
Deploying live


 ## Other
Created a singleton to hold the Org info