### PR TITLE
Bucket Policies must be delete_before_replace

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/pulumi-aws.yml
     needs: [ lint ]
     with:
-      AWS_REGION: us-east-1
+      AWS_REGION: {% endraw %}{{ aws_org_home_region }}{% raw %}
       PULUMI_STACK_NAME: prod
       PYTHON_VERSION: {% endraw %}{{ python_version }}{% raw %}
       DEPLOY_SCRIPT_MODULE_NAME: aws_central_infrastructure
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/pulumi-aws.yml
     needs: [ iac-management-pulumi ]
     with:
-      AWS_REGION: us-east-1
+      AWS_REGION: {% endraw %}{{ aws_org_home_region }}{% raw %}
       PULUMI_STACK_NAME: prod
       PYTHON_VERSION: {% endraw %}{{ python_version }}{% raw %}
       DEPLOY_SCRIPT_MODULE_NAME: aws_central_infrastructure
@@ -81,7 +81,7 @@ jobs:
     uses: ./.github/workflows/pulumi-aws.yml
     needs: [ iac-management-pulumi, artifact-stores-pulumi ] # Identity Center depends on outputs from the Artifact Stores stack to set up permission sets
     with:
-      AWS_REGION: us-east-1
+      AWS_REGION: {% endraw %}{{ aws_org_home_region }}{% raw %}
       PULUMI_STACK_NAME: prod
       PYTHON_VERSION: {% endraw %}{{ python_version }}{% raw %}
       DEPLOY_SCRIPT_MODULE_NAME: aws_central_infrastructure

--- a/template/src/aws_central_infrastructure/artifact_stores/lib/ssm_buckets.py
+++ b/template/src/aws_central_infrastructure/artifact_stores/lib/ssm_buckets.py
@@ -42,6 +42,7 @@ class ManualArtifactsBucket(ComponentResource):
         org_id = get_organization().id
         _ = s3.BucketPolicy(
             append_resource_suffix("manual-artifacts"),
+            opts=ResourceOptions(parent=self, delete_before_replace=True),
             bucket=self.bucket.bucket_name,  # type: ignore[reportArgumentType] # pyright somehow thinks a bucket name can be Output[None], which doesn't seem possible
             policy_document=self.bucket.bucket_name.apply(
                 lambda bucket_name: get_policy_document(
@@ -100,6 +101,7 @@ class DistributorPackagesBucket(ComponentResource):
         org_id = get_organization().id
         _ = s3.BucketPolicy(
             append_resource_suffix("distributor-packages"),
+            opts=ResourceOptions(parent=self, delete_before_replace=True),
             bucket=self.bucket.bucket_name,  # type: ignore[reportArgumentType] # pyright somehow thinks a bucket name can be Output[None], which doesn't seem possible
             policy_document=self.bucket.bucket_name.apply(
                 lambda bucket_name: get_policy_document(

--- a/template/src/aws_central_infrastructure/iac_management/lib/program.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/program.py
@@ -4,6 +4,7 @@ from ephemeral_pulumi_deploy import append_resource_suffix
 from ephemeral_pulumi_deploy import get_aws_account_id
 from ephemeral_pulumi_deploy import get_config
 from ephemeral_pulumi_deploy import get_config_str
+from pulumi import ResourceOptions
 from pulumi import export
 from pulumi_aws_native import Provider
 from pulumi_aws_native import s3
@@ -33,6 +34,7 @@ def pulumi_program() -> None:
         append_resource_suffix("central-iac-state"),
         bucket=central_state_bucket_name,
         policy_document=create_bucket_policy(central_state_bucket_name),
+        opts=ResourceOptions(delete_before_replace=True),
     )
 
     workloads_dict, params_dict = load_workload_info()


### PR DESCRIPTION
 ## Why is this change necessary?
A bucket can only have a single policy, therefore the Pulumi resource should use the delete_before_replace approach


 ## How does this change address the issue?
Adds that attribute to the central state and artifact buckets


 ## What side effects does this change have?
None


 ## How is this change tested?
Deployed to my AWS org


 ## Other
Parametized the AWS region based on copier question