### PR TITLE
Cloud Courier OIDC

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -87,10 +87,11 @@ configure_cloud_courier:
     help: Should Identity Center permissions be automatically configured to facilitate using Cloud Courier?
     default: no
 
-cloud_courier_repo_name:
+cloud_courier_infra_repo_name:
     type: str
     help: What is the name of the repository that contains the Cloud Courier Infrastructure?
     when: "{{ configure_cloud_courier }}"
+    default: "cloud-courier-infrastructure"
 
 # Additional Settings
 _min_copier_version: "9.4"

--- a/copier.yml
+++ b/copier.yml
@@ -87,6 +87,11 @@ configure_cloud_courier:
     help: Should Identity Center permissions be automatically configured to facilitate using Cloud Courier?
     default: no
 
+cloud_courier_repo_name:
+    type: str
+    help: What is the name of the repository that contains the Cloud Courier Infrastructure?
+    when: "{{ configure_cloud_courier }}"
+
 # Additional Settings
 _min_copier_version: "9.4"
 

--- a/template/src/aws_central_infrastructure/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/constants.py.jinja
@@ -1,2 +1,0 @@
-{% raw %}CENTRAL_INFRA_REPO_NAME = "{% endraw %}{{ repo_name }}{% raw %}"
-CENTRAL_INFRA_GITHUB_ORG_NAME = "{% endraw %}{{ central_infra_github_organization_name }}{% raw %}"{% endraw %}

--- a/template/src/aws_central_infrastructure/iac_management/github_oidc.py
+++ b/template/src/aws_central_infrastructure/iac_management/github_oidc.py
@@ -1,17 +1,19 @@
 from collections import defaultdict
 
-from ..constants import CENTRAL_INFRA_GITHUB_ORG_NAME
-from ..constants import CENTRAL_INFRA_REPO_NAME
 from .lib import AwsLogicalWorkload
 from .lib import GithubOidcConfig
 from .lib import WorkloadName
+from .lib import create_application_oidc_if_needed
 from .lib import create_oidc_for_single_account_workload
+from .lib.constants import CENTRAL_INFRA_GITHUB_ORG_NAME
+from .lib.constants import CENTRAL_INFRA_REPO_NAME
 
 
 def generate_all_oidc(
     *, workloads_info: dict[WorkloadName, AwsLogicalWorkload]
 ) -> dict[WorkloadName, list[GithubOidcConfig]]:
     all_oidc: dict[WorkloadName, list[GithubOidcConfig]] = defaultdict(list)
+    create_application_oidc_if_needed(all_oidc=all_oidc, workloads_info=workloads_info)
 
     workload_name = "identity-center"
     identity_center_workload = workloads_info[workload_name]

--- a/template/src/aws_central_infrastructure/iac_management/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/__init__.py
@@ -1,3 +1,4 @@
+from .application_oidc import create_application_oidc_if_needed
 from .github_oidc_lib import AwsAccountId
 from .github_oidc_lib import GithubOidcConfig
 from .github_oidc_lib import WorkloadName

--- a/template/src/aws_central_infrastructure/iac_management/lib/application_oidc.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/application_oidc.py
@@ -1,0 +1,23 @@
+from .constants import CENTRAL_INFRA_GITHUB_ORG_NAME
+from .constants import CLOUD_COURIER_INFRA_REPO_NAME
+from .constants import CONFIGURE_CLOUD_COURIER
+from .github_oidc_lib import GithubOidcConfig
+from .github_oidc_lib import WorkloadName
+from .github_oidc_lib import create_oidc_for_standard_workload
+from .shared_lib import AwsLogicalWorkload
+
+
+def create_application_oidc_if_needed(
+    *, all_oidc: dict[WorkloadName, list[GithubOidcConfig]], workloads_info: dict[WorkloadName, AwsLogicalWorkload]
+) -> None:
+    if not CONFIGURE_CLOUD_COURIER:
+        return
+    workload_name = "cloud-courier"
+    cloud_courier_workload = workloads_info[workload_name]
+    all_oidc[workload_name].extend(
+        create_oidc_for_standard_workload(
+            workload_info=cloud_courier_workload,
+            repo_org=CENTRAL_INFRA_GITHUB_ORG_NAME,
+            repo_name=CLOUD_COURIER_INFRA_REPO_NAME,
+        )
+    )

--- a/template/src/aws_central_infrastructure/iac_management/lib/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/iac_management/lib/constants.py.jinja
@@ -1,0 +1,4 @@
+{% raw %}CENTRAL_INFRA_REPO_NAME = "{% endraw %}{{ repo_name }}{% raw %}"
+CLOUD_COURIER_INFRA_REPO_NAME  = "{% endraw %}{{ cloud_courier_infra_repo_name }}{% raw %}"
+CENTRAL_INFRA_GITHUB_ORG_NAME = "{% endraw %}{{ central_infra_github_organization_name }}{% raw %}"
+CONFIGURE_CLOUD_COURIER = {% endraw %}{{ 'True' if configure_cloud_courier else 'False' }}

--- a/template/src/aws_central_infrastructure/iac_management/lib/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/iac_management/lib/constants.py.jinja
@@ -1,4 +1,4 @@
 {% raw %}CENTRAL_INFRA_REPO_NAME = "{% endraw %}{{ repo_name }}{% raw %}"
-CLOUD_COURIER_INFRA_REPO_NAME  = "{% endraw %}{{ cloud_courier_infra_repo_name }}{% raw %}"
+CLOUD_COURIER_INFRA_REPO_NAME = "{% endraw %}{{ cloud_courier_infra_repo_name }}{% raw %}"
 CENTRAL_INFRA_GITHUB_ORG_NAME = "{% endraw %}{{ central_infra_github_organization_name }}{% raw %}"
 CONFIGURE_CLOUD_COURIER = {% endraw %}{{ 'True' if configure_cloud_courier else 'False' }}

--- a/template/src/aws_central_infrastructure/iac_management/lib/pulumi_bootstrap.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/pulumi_bootstrap.py
@@ -13,7 +13,7 @@ from pulumi_aws_native import Provider
 from pulumi_aws_native import ProviderAssumeRoleArgs
 from pulumi_aws_native import ssm
 
-from ...constants import CENTRAL_INFRA_REPO_NAME
+from .constants import CENTRAL_INFRA_REPO_NAME
 from .github_oidc_lib import AwsAccountId
 from .shared_lib import ORG_MANAGED_SSM_PARAM_PREFIX
 from .shared_lib import AwsAccountInfo

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/constants.py.jinja
@@ -1,1 +1,0 @@
-{% raw %}CONFIGURE_CLOUD_COURIER = {% endraw %}{{ 'True' if configure_cloud_courier else 'False' }}

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -22,3 +22,4 @@ central_infra_github_organization_name: foobar
 initial_iac_management_deploy_occurred: true
 identity_center_production_account_id: 123499989012
 configure_cloud_courier: true
+cloud_courier_repo_name: my-cloud-courier-infra

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -22,4 +22,4 @@ central_infra_github_organization_name: foobar
 initial_iac_management_deploy_occurred: true
 identity_center_production_account_id: 123499989012
 configure_cloud_courier: true
-cloud_courier_repo_name: my-cloud-courier-infra
+cloud_courier_infra_repo_name: my-cloud-courier-infra


### PR DESCRIPTION
 ## Why is this change necessary?
Need to have a standardized creation of OIDC Github for Cloud Courier infrastructure repo


 ## How does this change address the issue?
Adds it into the template


 ## What side effects does this change have?
None


 ## How is this change tested?
In my AWS Org---no pulumi diff compared to current state


 ## Other
consolidated the two separate constants.py.jinja files