### PR TITLE
Management permission set assignments

### DIFF
--- a/template/src/aws_central_infrastructure/iac_management/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/__init__.py
@@ -7,4 +7,5 @@ from .github_oidc_lib import create_oidc_for_standard_workload
 from .pulumi_bootstrap import create_providers
 from .shared_lib import ORG_MANAGED_SSM_PARAM_PREFIX
 from .shared_lib import AwsLogicalWorkload
+from .workload_params import get_management_account_id
 from .workload_params import load_workload_info

--- a/template/src/aws_central_infrastructure/iac_management/lib/program.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/program.py
@@ -4,17 +4,21 @@ from ephemeral_pulumi_deploy import append_resource_suffix
 from ephemeral_pulumi_deploy import get_aws_account_id
 from ephemeral_pulumi_deploy import get_config
 from ephemeral_pulumi_deploy import get_config_str
+from ephemeral_pulumi_deploy.utils import common_tags
 from pulumi import ResourceOptions
 from pulumi import export
 from pulumi_aws_native import Provider
 from pulumi_aws_native import s3
+from pulumi_aws_native import ssm
 
 from ..github_oidc import generate_all_oidc
 from .github_oidc_lib import AwsAccountId
 from .github_oidc_lib import deploy_all_oidc
 from .pulumi_bootstrap import AwsWorkloadPulumiBootstrap
 from .pulumi_bootstrap import create_bucket_policy
+from .shared_lib import MANAGEMENT_ACCOUNT_ID_PARAM_NAME
 from .workload_params import WorkloadParams
+from .workload_params import get_management_account_id
 from .workload_params import load_workload_info
 
 logger = logging.getLogger(__name__)
@@ -50,6 +54,18 @@ def pulumi_program() -> None:
         name="identity-center",
         params_dict=params_dict,
         provider=providers[workloads_dict["identity-center"].prod_accounts[0].id],
+    )
+
+    _ = ssm.Parameter(
+        append_resource_suffix("identity-center-management-account-id"),
+        type=ssm.ParameterType.STRING,
+        name=MANAGEMENT_ACCOUNT_ID_PARAM_NAME,
+        description="AWS Org Management Account ID",
+        tags=common_tags(),
+        value=get_management_account_id(),
+        opts=ResourceOptions(
+            provider=providers[workloads_dict["identity-center"].prod_accounts[0].id], delete_before_replace=True
+        ),
     )
     all_oidc = generate_all_oidc(workloads_info=workloads_dict)
     deploy_all_oidc(

--- a/template/src/aws_central_infrastructure/iac_management/lib/program.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/program.py
@@ -57,7 +57,7 @@ def pulumi_program() -> None:
     )
 
     _ = ssm.Parameter(
-        append_resource_suffix("identity-center-management-account-id"),
+        append_resource_suffix("identity-center-management-account-id", max_length=75),
         type=ssm.ParameterType.STRING,
         name=MANAGEMENT_ACCOUNT_ID_PARAM_NAME,
         description="AWS Org Management Account ID",

--- a/template/src/aws_central_infrastructure/iac_management/lib/shared_lib.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/shared_lib.py
@@ -5,6 +5,7 @@ from pydantic import Field
 
 ORG_MANAGED_SSM_PARAM_PREFIX = "/org-managed"
 WORKLOAD_INFO_SSM_PARAM_PREFIX = f"{ORG_MANAGED_SSM_PARAM_PREFIX}/logical-workloads"
+MANAGEMENT_ACCOUNT_ID_PARAM_NAME = f"{ORG_MANAGED_SSM_PARAM_PREFIX}/management-account-id"
 
 
 class AwsAccountInfo(BaseModel, frozen=True):

--- a/template/src/aws_central_infrastructure/iac_management/lib/workload_params.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/workload_params.py
@@ -9,6 +9,7 @@ from pulumi_aws_native import Provider
 from pulumi_aws_native import ssm
 
 from .github_oidc_lib import WorkloadName
+from .shared_lib import MANAGEMENT_ACCOUNT_ID_PARAM_NAME
 from .shared_lib import WORKLOAD_INFO_SSM_PARAM_PREFIX
 from .shared_lib import AwsLogicalWorkload
 
@@ -86,3 +87,13 @@ def load_workload_info(
         # The Central Infra "workload" is unique and can't generally be managed by the same process as the other workloads
         del workloads_dict["central-infra"]  # remove the Central Infra workload from the dictionary
     return workloads_dict, params_dict
+
+
+def get_management_account_id() -> str:
+    ssm_client = boto3.client("ssm", region_name=get_config_str("proj:aws_org_home_region"))
+    response = ssm_client.get_parameter(  # TODO: consider using get_parameters for just a single API call
+        Name=MANAGEMENT_ACCOUNT_ID_PARAM_NAME,
+    )
+    param_dict = response["Parameter"]
+    assert "Value" in param_dict, f"Value not found in parameter {param_dict}"
+    return param_dict["Value"]

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/__init__.py
@@ -1,5 +1,6 @@
 from .lib import User
 from .lib import UserInfo
+from .lib import Username
 from .lib import all_created_users
 from .lib import create_read_state_inline_policy
 from .permissions import LOW_RISK_ADMIN_PERM_SET_CONTAINER
@@ -10,3 +11,4 @@ from .permissions import AwsSsoPermissionSet
 from .permissions import AwsSsoPermissionSetAccountAssignments
 from .permissions import AwsSsoPermissionSetContainer
 from .permissions import DefaultWorkloadPermissionAssignments
+from .permissions import create_org_admin_permissions

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -7,6 +7,7 @@ from pulumi_aws import identitystore as identitystore_classic
 from pulumi_aws import ssoadmin
 from pydantic import BaseModel
 
+from aws_central_infrastructure.iac_management.lib import get_management_account_id
 from aws_central_infrastructure.iac_management.lib.shared_lib import AwsAccountInfo
 from aws_central_infrastructure.iac_management.lib.shared_lib import AwsLogicalWorkload
 
@@ -182,3 +183,26 @@ class DefaultWorkloadPermissionAssignments(BaseModel):
                 permission_set=LOW_RISK_ADMIN_PERM_SET_CONTAINER.permission_set,
                 users=self.users,
             )
+
+
+def create_org_admin_permissions(
+    *, workloads_dict: dict[str, AwsLogicalWorkload], users: list[UserInfo] | None = None
+) -> None:
+    view_only_permission_set = VIEW_ONLY_PERM_SET_CONTAINER.permission_set
+
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=workloads_dict["central-infra"].prod_accounts[0],
+        permission_set=view_only_permission_set,
+        users=users,
+    )
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=workloads_dict["identity-center"].prod_accounts[0],
+        permission_set=view_only_permission_set,
+        users=users,
+    )
+
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=AwsAccountInfo(id=get_management_account_id(), name="management"),
+        permission_set=view_only_permission_set,
+        users=users,
+    )

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/permissions.py
@@ -2,10 +2,13 @@ from aws_central_infrastructure.iac_management.lib import AwsLogicalWorkload
 
 from .lib import LOW_RISK_ADMIN_PERM_SET_CONTAINER
 from .lib import VIEW_ONLY_PERM_SET_CONTAINER
+from .lib import create_org_admin_permissions
 from .lib import create_read_state_inline_policy
 
 
-def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:  # noqa: ARG001 # this argument will be used when the template is instantiated
+def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:
     _ = LOW_RISK_ADMIN_PERM_SET_CONTAINER.create_permission_set()
 
     _ = VIEW_ONLY_PERM_SET_CONTAINER.create_permission_set(inline_policy=create_read_state_inline_policy())
+
+    create_org_admin_permissions(workloads_dict=workloads_dict, users=[])


### PR DESCRIPTION
 ## Why is this change necessary?
Create view only permission set assignments for AWS org managers.


 ## How does this change address the issue?
Creates them for root account, central infra, and identity center


 ## What side effects does this change have?
N/A


 ## How is this change tested?
Isn't really


