### PR TITLE
Billing delegate permission

### DIFF
--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -7,7 +7,6 @@ from pulumi_aws import identitystore as identitystore_classic
 from pulumi_aws import ssoadmin
 from pydantic import BaseModel
 
-from aws_central_infrastructure.iac_management.lib import get_management_account_id
 from aws_central_infrastructure.iac_management.lib.shared_lib import AwsAccountInfo
 from aws_central_infrastructure.iac_management.lib.shared_lib import AwsLogicalWorkload
 
@@ -202,7 +201,7 @@ def create_org_admin_permissions(
     )
 
     _ = AwsSsoPermissionSetAccountAssignments(
-        account_info=AwsAccountInfo(id=get_management_account_id(), name="management"),
+        account_info=workloads_dict["billing-delegate"].prod_accounts[0],
         permission_set=view_only_permission_set,
         users=users,
     )

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -114,9 +114,9 @@ VIEW_ONLY_PERM_SET_CONTAINER = AwsSsoPermissionSetContainer(
         "AWSLambda_ReadOnlyAccess",  # review traces and logs for debugging Lambdas easily through the console
         "CloudWatchEventsReadOnlyAccess",  # see information about event rules and patterns
         "AmazonEventBridgeReadOnlyAccess",  # see basic metrics about Event Bridges to troubleshoot
-        "AmazonEventBridgeSchemasReadOnlyAccess",  # look at basic metrics about EventBridge Schemas to troubleshoot
         "AmazonEC2ContainerRegistryReadOnly",  # describe ECR images,
         "AWSBillingReadOnlyAccess",  # view billing information to help optimize costs
+        # TODO: figure out how to add back in AmazonEventBridgeSchemasReadOnlyAccess permission...but we're at the limit of managed policies that can be attached currently
     ],
 )
 

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -115,7 +115,8 @@ VIEW_ONLY_PERM_SET_CONTAINER = AwsSsoPermissionSetContainer(
         "CloudWatchEventsReadOnlyAccess",  # see information about event rules and patterns
         "AmazonEventBridgeReadOnlyAccess",  # see basic metrics about Event Bridges to troubleshoot
         "AmazonEventBridgeSchemasReadOnlyAccess",  # look at basic metrics about EventBridge Schemas to troubleshoot
-        "AmazonEC2ContainerRegistryReadOnly",  # describe ECR images
+        "AmazonEC2ContainerRegistryReadOnly",  # describe ECR images,
+        "AWSBillingReadOnlyAccess",  # view billing information to help optimize costs
     ],
 )
 

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -114,10 +114,10 @@ VIEW_ONLY_PERM_SET_CONTAINER = AwsSsoPermissionSetContainer(
         "AmazonEventBridgeReadOnlyAccess",  # see basic metrics about Event Bridges to troubleshoot
         "AmazonEC2ContainerRegistryReadOnly",  # describe ECR images,
         "AWSBillingReadOnlyAccess",  # view billing information to help optimize costs
+        "CostOptimizationHubReadOnlyAccess",  # view actual costs and usage
         # TODO: figure out how to add back in AmazonEventBridgeSchemasReadOnlyAccess permission...but we're at the limit of managed policies that can be attached currently
         # TODO: figure out how to add back in "AmazonAppStreamReadOnlyAccess",  # look at the details of stack/fleet information to troubleshoot any issues
         # TODO: "CloudWatchEventsReadOnlyAccess",  # see information about event rules and patterns
-        # CostOptimizationHubReadOnlyAccess
     ],
 )
 

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -109,14 +109,15 @@ VIEW_ONLY_PERM_SET_CONTAINER = AwsSsoPermissionSetContainer(
         "AWSSupportAccess",  # Allow users to request AWS support for technical questions.
         "job-function/ViewOnlyAccess",  # wide ranging attribute view access across a variety of services
         "CloudWatchReadOnlyAccess",  # be able to read CloudWatch logs/metrics/etc
-        "AmazonAppStreamReadOnlyAccess",  # look at the details of stack/fleet information to troubleshoot any issues
         "AmazonSSMReadOnlyAccess",  # look at SSM fleet/hybrid activation details
         "AWSLambda_ReadOnlyAccess",  # review traces and logs for debugging Lambdas easily through the console
-        "CloudWatchEventsReadOnlyAccess",  # see information about event rules and patterns
         "AmazonEventBridgeReadOnlyAccess",  # see basic metrics about Event Bridges to troubleshoot
         "AmazonEC2ContainerRegistryReadOnly",  # describe ECR images,
         "AWSBillingReadOnlyAccess",  # view billing information to help optimize costs
         # TODO: figure out how to add back in AmazonEventBridgeSchemasReadOnlyAccess permission...but we're at the limit of managed policies that can be attached currently
+        # TODO: figure out how to add back in "AmazonAppStreamReadOnlyAccess",  # look at the details of stack/fleet information to troubleshoot any issues
+        # TODO: "CloudWatchEventsReadOnlyAccess",  # see information about event rules and patterns
+        # CostOptimizationHubReadOnlyAccess
     ],
 )
 


### PR DESCRIPTION
 ## Why is this change necessary?
The view only permission set needed the ability to see some basic things about costs. Also, permission sets can't actually be assigned to the management account from the Identity center delegate, so needed to assign it to a billing delegate account


 ## How does this change address the issue?
Adds permissions


 ## What side effects does this change have?
Since only 10 managed policies can be attached to a permission set, some others needed to be removed


 ## How is this change tested?
In my AWS Org


 ## Other
There's still some tweaking that needs to be made to improve the permissions for billing