### PR TITLE
Manage Github Repos

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -82,6 +82,11 @@ identity_center_production_account_id:
     type: str
     help: What is the account ID for the delegated account to manage the AWS Identity Center?
 
+manage_github_repos:
+    type: bool
+    help: Do you want to use this repository to manage some of the other GitHub repositories through Infrastructure as Code?
+    default: no
+
 configure_cloud_courier:
     type: bool
     help: Should Identity Center permissions be automatically configured to facilitate using Cloud Courier?

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -61,10 +61,10 @@ jobs:
       PULUMI_UP: ${{ github.ref == 'refs/heads/main' }}
       PULUMI_UP_ROLE_NAME: InfraDeploy--{% endraw %}{{ repo_name }}{% raw %}
       AWS_ACCOUNT_ID: "{% endraw %}{{ aws_production_account_id }}{% raw %}"
-{% endraw %}{% if initial_iac_management_deploy_occurred %}{% raw %}
+{% endraw %}{% if manage_github_repos %}{% raw %}
   github-repos-pulumi:
     uses: ./.github/workflows/pulumi-aws.yml
-    needs: [ iac-management-pulumi, artifact-stores-pulumi ] # Identity Center depends on outputs from the Artifact Stores stack to set up permission sets
+    needs: [ lint ]
     with:
       AWS_REGION: {% endraw %}{{ aws_org_home_region }}{% raw %}
       PULUMI_STACK_NAME: prod
@@ -109,7 +109,7 @@ jobs:
 
   required-check:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
-    needs: [ lint, iac-management-pulumi, artifact-stores-pulumi{% endraw %}{% if initial_iac_management_deploy_occurred %}{% raw %}, identity-center-pulumi{% endraw %}{% endif %}{% if initial_iac_management_deploy_occurred %}{% raw %}, github-repos-pulumi{% endraw %}{% endif %}{% raw %} ]
+    needs: [ lint, iac-management-pulumi, artifact-stores-pulumi{% endraw %}{% if initial_iac_management_deploy_occurred %}{% raw %}, identity-center-pulumi{% endraw %}{% endif %}{% if manage_github_repos %}{% raw %}, github-repos-pulumi{% endraw %}{% endif %}{% raw %} ]
     if: always()
     steps:
       - name: fail if prior job failure

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -61,6 +61,21 @@ jobs:
       PULUMI_UP: ${{ github.ref == 'refs/heads/main' }}
       PULUMI_UP_ROLE_NAME: InfraDeploy--{% endraw %}{{ repo_name }}{% raw %}
       AWS_ACCOUNT_ID: "{% endraw %}{{ aws_production_account_id }}{% raw %}"
+{% endraw %}{% if initial_iac_management_deploy_occurred %}{% raw %}
+  github-repos-pulumi:
+    uses: ./.github/workflows/pulumi-aws.yml
+    needs: [ iac-management-pulumi, artifact-stores-pulumi ] # Identity Center depends on outputs from the Artifact Stores stack to set up permission sets
+    with:
+      AWS_REGION: {% endraw %}{{ aws_org_home_region }}{% raw %}
+      PULUMI_STACK_NAME: prod
+      PYTHON_VERSION: {% endraw %}{{ python_version }}{% raw %}
+      DEPLOY_SCRIPT_MODULE_NAME: aws_central_infrastructure
+      DEPLOY_SCRIPT_NAME: deploy_github_repos
+      PULUMI_PREVIEW: true
+      PREVIEW_ROLE_NAME: InfraPreview--{% endraw %}{{ repo_name }}{% raw %}
+      PULUMI_UP: ${{ github.ref == 'refs/heads/main' }}
+      PULUMI_UP_ROLE_NAME: InfraDeploy--{% endraw %}{{ repo_name }}{% raw %}
+      AWS_ACCOUNT_ID: "{% endraw %}{{ aws_production_account_id }}{% raw %}"{% endraw %}{% endif %}{% raw %}
 
   artifact-stores-pulumi:
     uses: ./.github/workflows/pulumi-aws.yml
@@ -94,10 +109,10 @@ jobs:
 
   required-check:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
-    needs: [ lint, iac-management-pulumi, artifact-stores-pulumi{% endraw %}{% if initial_iac_management_deploy_occurred %}{% raw %}, identity-center-pulumi{% endraw %}{% endif %}{% raw %} ]
+    needs: [ lint, iac-management-pulumi, artifact-stores-pulumi{% endraw %}{% if initial_iac_management_deploy_occurred %}{% raw %}, identity-center-pulumi{% endraw %}{% endif %}{% if initial_iac_management_deploy_occurred %}{% raw %}, github-repos-pulumi{% endraw %}{% endif %}{% raw %} ]
     if: always()
     steps:
       - name: fail if prior job failure
-        if: needs.lint.result != 'success' || needs.iac-management-pulumi.result != 'success' || needs.artifact-stores-pulumi.result != 'success'{% endraw %}{% if initial_iac_management_deploy_occurred %}{% raw %} || needs.identity-center-pulumi.result != 'success'{% endraw %}{% endif %}{% raw %}
+        if: needs.lint.result != 'success' || needs.iac-management-pulumi.result != 'success' || needs.artifact-stores-pulumi.result != 'success'{% endraw %}{% if initial_iac_management_deploy_occurred %}{% raw %} || needs.identity-center-pulumi.result != 'success'{% endraw %}{% endif %}{% if manage_github_repos %}{% raw %} || needs.github-repos-pulumi.result != 'success'{% endraw %}{% endif %}{% raw %}
         run: |
           exit 1{% endraw %}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -21,7 +21,8 @@ To create a new repository using this template:
 ## Using Pulumi
 Run a Pulumi Preview for the IaC Management project: `uv run python -m aws_central_infrastructure.deploy_iac_management --stack=prod`
 Run a Pulumi Preview for the Artifact Stores project: `uv run python -m aws_central_infrastructure.deploy_artifact_stores --stack=prod`
-Run a Pulumi Preview for the Identity Center project: `uv run python -m aws_central_infrastructure.deploy_identity_center --stack=prod`
+Run a Pulumi Preview for the Identity Center project: `uv run python -m aws_central_infrastructure.deploy_identity_center --stack=prod`{% endraw %}{% if manage_github_repos %}{% raw%}
+Run a Pulumi Preview for the GitHub Repositories project: `uv run python -m aws_central_infrastructure.deploy_github_repos --stack=prod`{% endraw %}{% endif %}{% raw %}
 
 
 ## Updating from the template

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -18,7 +18,8 @@ dependencies = [
     "pulumi>={% endraw %}{{ pulumi_version }}{% raw %}",
     "pulumi-aws>={% endraw %}{{ pulumi_aws_version }}{% raw %}",
     "pulumi-aws-native>={% endraw %}{{ pulumi_aws_native_version }}{% raw %}",
-    "pulumi-command>={% endraw %}{{ pulumi_command_version }}{% raw %}",
+    "pulumi-command>={% endraw %}{{ pulumi_command_version }}{% raw %}",{% endraw %}{% if manage_github_repos %}{% raw %}
+    "pulumi-github>=6.7.0",{% endraw %}{% endif %}{% raw %}
     "ephemeral-pulumi-deploy>={% endraw %}{{ ephemeral_pulumi_deploy_version }}{% raw %}",
     "boto3>={% endraw %}{{ boto3_version }}{% raw %}",
     "boto3-stubs[all]=={% endraw %}{{ boto3_version }}{% raw %}", # there's a bug/conflict in 1.37.4 affecting pyright: https://github.com/LabAutomationAndScreening/copier-cloud-courier-infrastructure/actions/runs/13596390146/job/38014193360#step:11:69

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/__init__.py
@@ -4,6 +4,7 @@ from .lib import Username
 from .lib import all_created_users
 from .lib import create_read_state_inline_policy
 from .permissions import LOW_RISK_ADMIN_PERM_SET_CONTAINER
+from .permissions import MANUAL_SECRETS_ENTRY_PERM_SET_CONTAINER
 from .permissions import VIEW_ONLY_PERM_SET_CONTAINER
 from .permissions import AwsAccountInfo
 from .permissions import AwsLogicalWorkload

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/program.py.jinja
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/program.py.jinja
@@ -9,6 +9,9 @@ from aws_central_infrastructure.iac_management.lib.workload_params import load_w
 {% endraw %}{% if configure_cloud_courier %}{% raw %}from ..cloud_courier_permissions import configure_cloud_courier_permissions
 {% endraw %}{% endif %}{% raw %}from ..permissions import create_permissions
 from ..users import create_users
+from .permissions import LOW_RISK_ADMIN_PERM_SET_CONTAINER
+from .permissions import MANUAL_SECRETS_ENTRY_PERM_SET_CONTAINER
+from .permissions import VIEW_ONLY_PERM_SET_CONTAINER
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +27,9 @@ def pulumi_program() -> None:
     workloads_dict, _ = load_workload_info(exclude_central_infra_workload=False)
     # Note: If you are directly creating users (and not using your external SSO Identity Provider), you must create any new users and deploy them before you can assign any permissions to them (otherwise the Preview will fail)
     create_users()
+    _ = LOW_RISK_ADMIN_PERM_SET_CONTAINER.create_permission_set()
+    _ = MANUAL_SECRETS_ENTRY_PERM_SET_CONTAINER.create_permission_set()
+    _ = VIEW_ONLY_PERM_SET_CONTAINER.create_permission_set()
     create_permissions(workloads_dict)
 
     # Application-specific permissions managed by copier template{% endraw %}{% if configure_cloud_courier %}{% raw %}

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/permissions.py
@@ -3,12 +3,11 @@ from aws_central_infrastructure.iac_management.lib import AwsLogicalWorkload
 from .lib import LOW_RISK_ADMIN_PERM_SET_CONTAINER
 from .lib import VIEW_ONLY_PERM_SET_CONTAINER
 from .lib import create_org_admin_permissions
-from .lib import create_read_state_inline_policy
 
 
 def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:
-    _ = LOW_RISK_ADMIN_PERM_SET_CONTAINER.create_permission_set()
+    _ = LOW_RISK_ADMIN_PERM_SET_CONTAINER.permission_set
 
-    _ = VIEW_ONLY_PERM_SET_CONTAINER.create_permission_set(inline_policy=create_read_state_inline_policy())
+    _ = VIEW_ONLY_PERM_SET_CONTAINER.permission_set
 
     create_org_admin_permissions(workloads_dict=workloads_dict, users=[])

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}deploy_github_repos.py{% endif %}.jinja
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}deploy_github_repos.py{% endif %}.jinja
@@ -1,0 +1,30 @@
+{% raw %}import logging
+from typing import Any
+
+from ephemeral_pulumi_deploy import run_cli
+from pulumi.automation import ConfigValue
+
+from .github_repos.lib.program import pulumi_program
+
+logger = logging.getLogger(__name__)
+
+
+# pylint:disable=duplicate-code # there's not much to DRY up here, it's some commonalities between the two deploy scripts
+def generate_stack_config() -> dict[str, Any]:
+    """Generate the stack configuration."""
+    stack_config: dict[str, Any] = {}
+    stack_config["proj:pulumi_project_name"] = "github-repos"
+    stack_config["proj:aws_org_home_region"] = ConfigValue(value="{% endraw %}{{ aws_org_home_region }}{% raw %}")
+    github_repo_name = "{% endraw %}{{ repo_name }}{% raw %}"
+    stack_config["proj:github_repo_name"] = github_repo_name
+
+    stack_config["proj:git_repository_url"] = ConfigValue(value=f"https://github.com/{% endraw %}{{ central_infra_github_organization_name }}{% raw %}/{github_repo_name}")
+    return stack_config
+
+
+def main() -> None:
+    run_cli(stack_config=generate_stack_config(), pulumi_program=pulumi_program)
+
+
+if __name__ == "__main__":
+    main(){% endraw %}

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}deploy_github_repos.py{% endif %}.jinja
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}deploy_github_repos.py{% endif %}.jinja
@@ -18,7 +18,9 @@ def generate_stack_config() -> dict[str, Any]:
     github_repo_name = "{% endraw %}{{ repo_name }}{% raw %}"
     stack_config["proj:github_repo_name"] = github_repo_name
 
-    stack_config["proj:git_repository_url"] = ConfigValue(value=f"https://github.com/{% endraw %}{{ central_infra_github_organization_name }}{% raw %}/{github_repo_name}")
+    stack_config["proj:git_repository_url"] = ConfigValue(value=f"https://github.com/{% endraw %}{{ repo_org_name }}{% raw %}/{github_repo_name}")
+
+    stack_config["github:owner"] = ConfigValue(value="{% endraw %}{{ repo_org_name }}{% raw %}")
     return stack_config
 
 

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/__init__.py
@@ -1,0 +1,3 @@
+from .repo import GithubRepo
+from .repo import GithubRepoConfig
+from .repo import create_repos

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
@@ -1,0 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def pulumi_program() -> None:
+    """Execute creating the stack."""

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
@@ -1,7 +1,12 @@
 import logging
 
+from ..repos import create_repo_configs
+from .repo import create_repos
+
 logger = logging.getLogger(__name__)
 
 
 def pulumi_program() -> None:
     """Execute creating the stack."""
+    configs = create_repo_configs()
+    create_repos(configs)

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -1,0 +1,131 @@
+from collections.abc import Iterable
+from collections.abc import Sequence
+from typing import Literal
+
+import boto3
+from ephemeral_pulumi_deploy import append_resource_suffix
+from ephemeral_pulumi_deploy import get_config_str
+from ephemeral_pulumi_deploy.utils import common_tags_native
+from pulumi import ComponentResource
+from pulumi import ResourceOptions
+from pulumi.runtime import is_dry_run
+from pulumi_aws_native import secretsmanager
+from pulumi_github import Provider
+from pulumi_github import Repository
+from pulumi_github import RepositoryRuleset
+from pulumi_github import RepositoryRulesetBypassActorArgs
+from pulumi_github import RepositoryRulesetConditionsArgs
+from pulumi_github import RepositoryRulesetConditionsRefNameArgs
+from pulumi_github import RepositoryRulesetRulesArgs
+from pulumi_github import RepositoryRulesetRulesPullRequestArgs
+from pulumi_github import RepositoryRulesetRulesRequiredStatusChecksArgs
+from pulumi_github import RepositoryRulesetRulesRequiredStatusChecksRequiredCheckArgs
+from pydantic import BaseModel
+
+
+class GithubRepoConfig(BaseModel, frozen=True):
+    name: str
+    visibility: Literal["private", "public"] = "private"
+    description: str
+    allow_merge_commit: bool = False
+    allow_rebase_merge: bool = False
+    delete_branch_on_merge: bool = True
+    has_issues: bool = True
+    allow_auto_merge: bool = True
+    squash_merge_commit_title: str = "PR_TITLE"
+    squash_merge_commit_message: str = "PR_BODY"
+    require_branch_to_be_up_to_date_before_merge: bool = True
+    org_admin_rule_bypass: bool = False
+
+
+class GithubRepo(ComponentResource):
+    def __init__(self, *, config: GithubRepoConfig, provider: Provider | None = None):
+        super().__init__("labauto:GithubRepo", append_resource_suffix(config.name), None)
+        repo = Repository(
+            append_resource_suffix(config.name),
+            name=config.name,
+            visibility=config.visibility,
+            description=config.description,
+            allow_merge_commit=config.allow_merge_commit,
+            allow_rebase_merge=config.allow_rebase_merge,
+            delete_branch_on_merge=config.delete_branch_on_merge,
+            has_issues=config.has_issues,
+            allow_auto_merge=config.allow_auto_merge,
+            squash_merge_commit_title=config.squash_merge_commit_title,
+            squash_merge_commit_message=config.squash_merge_commit_message,
+            auto_init=True,
+            opts=ResourceOptions(provider=provider, parent=self),
+        )
+        bypass_actors: Sequence[RepositoryRulesetBypassActorArgs] | None = None
+        if config.org_admin_rule_bypass:
+            bypass_actors = [
+                RepositoryRulesetBypassActorArgs(
+                    actor_type="OrganizationAdmin",
+                    bypass_mode="pull_request",
+                    actor_id=1,  # Pulumi requires some value for actor_id, but it doesn't seem to be used when actor_type is set to Org Admin
+                )
+            ]
+        _ = RepositoryRuleset(
+            append_resource_suffix(config.name),
+            bypass_actors=bypass_actors,
+            name="Protect Default Branch",
+            repository=repo.name,
+            target="branch",
+            enforcement="active",
+            conditions=RepositoryRulesetConditionsArgs(
+                ref_name=RepositoryRulesetConditionsRefNameArgs(includes=["~DEFAULT_BRANCH"], excludes=[])
+            ),
+            rules=RepositoryRulesetRulesArgs(
+                deletion=True,
+                non_fast_forward=True,
+                required_status_checks=RepositoryRulesetRulesRequiredStatusChecksArgs(
+                    required_checks=[
+                        RepositoryRulesetRulesRequiredStatusChecksRequiredCheckArgs(context="required-check")
+                    ],
+                    strict_required_status_checks_policy=config.require_branch_to_be_up_to_date_before_merge,
+                ),
+                pull_request=RepositoryRulesetRulesPullRequestArgs(
+                    dismiss_stale_reviews_on_push=True,
+                    require_last_push_approval=True,
+                    required_approving_review_count=1,
+                    # TODO: set the Allowed Merge Methods once that becomes available through Pulumi
+                ),
+            ),
+            opts=ResourceOptions(provider=provider, parent=self, depends_on=[repo]),
+        )
+
+
+def create_repos(configs: Iterable[GithubRepoConfig] | None = None) -> None:
+    # Token permissions needed: All repositories, Administration: Read & write, Environments: Read & write, Contents: read & write
+    _ = secretsmanager.Secret(
+        append_resource_suffix("github-access-token"),
+        name="/manually-entered-secrets/iac/github-access-token",
+        description="GitHub access token",
+        secret_string="will-need-to-be-manually-entered",  # noqa: S106 # this is not a real secret
+        tags=common_tags_native(),
+        opts=ResourceOptions(ignore_changes=["secret_string"]),
+    )
+
+    if configs is None:
+        configs = []
+    if not configs:
+        return
+    token = "fake"  # noqa: S105 # this is not a real secret
+    if not is_dry_run():  # the Pulumi Preview process doesn't seem to actually invoke the Github API, so only grant the Deploy role the ability to get this secret and ignore it during Preview
+        # Trying to use pulumi_aws GetSecretVersionResult isn't working because it still returns an Output, and Provider requires a string. Even attempting to use apply
+        secrets_client = boto3.client("secretsmanager")
+        secrets_response = secrets_client.list_secrets(
+            Filters=[{"Key": "name", "Values": ["/manually-entered-secrets/iac/github-access-token"]}]
+        )
+        secrets = secrets_response["SecretList"]
+        assert len(secrets) == 1, f"expected only 1 matching secret, but found {len(secrets)}"
+        assert "ARN" in secrets[0], f"expected 'ARN' in secrets[0], but found {secrets[0].keys()}"
+        secret_id = secrets[0]["ARN"]
+        token = secrets_client.get_secret_value(SecretId=secret_id)["SecretString"]
+
+    provider = Provider(  # TODO: figure out why this isn't getting automatically picked up from the config
+        "default", token=token, owner=get_config_str("github:owner")
+    )
+
+    for config in configs:
+        _ = GithubRepo(config=config, provider=provider)

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -97,6 +97,7 @@ class GithubRepo(ComponentResource):
 
 def create_repos(configs: Iterable[GithubRepoConfig] | None = None) -> None:
     # Token permissions needed: All repositories, Administration: Read & write, Environments: Read & write, Contents: read & write
+    # After the initial deployment which creates the secret, go in and use the Manual Secrets permission set to update the secret with the real token, then you can create repos
     _ = secretsmanager.Secret(
         append_resource_suffix("github-access-token"),
         name="/manually-entered-secrets/iac/github-access-token",

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/repos.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/repos.py
@@ -1,0 +1,14 @@
+from collections.abc import Iterable
+
+from .lib import GithubRepoConfig
+
+
+def create_repo_configs() -> Iterable[GithubRepoConfig]:
+    """Create the configurations for the repositories.
+
+    example: `configs.append(GithubRepoConfig(name="test-pulumi-repo", description="blah"))`
+    """
+    configs: list[GithubRepoConfig] = []
+    # Append repos to the list here
+
+    return configs

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -18,3 +18,4 @@ central_infra_github_organization_name: my-org
 initial_iac_management_deploy_occurred: false
 identity_center_production_account_id: 023202320444
 configure_cloud_courier: false
+manage_github_repos: false

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -23,3 +23,4 @@ initial_iac_management_deploy_occurred: true
 identity_center_production_account_id: 123499989012
 configure_cloud_courier: true
 cloud_courier_infra_repo_name: my-cloud-courier-infra
+manage_github_repos: true


### PR DESCRIPTION
 ## Why is this change necessary?
Add ability to manage github repos


 ## How does this change address the issue?
Adds a permission set for manual secrets entry (for the github token).
Adds a new stack that has the ability to instantiate a github repo with standard settings and branch protection ruleset.


 ## What side effects does this change have?
None


 ## How is this change tested?
A downstream repo
