### PR TITLE
Code artifact CI Role

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.7-28-g37a4fb5
+_commit: v0.0.7-44-gea357db
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing Central Infrastructure of an AWS Organization
 python_ci_versions:

--- a/.github/actions/install_deps_uv/action.yml
+++ b/.github/actions/install_deps_uv/action.yml
@@ -14,6 +14,19 @@ inputs:
     description: What's the relative path to the project?
     required: false
     default: ./
+  code-artifact-auth-role-name:
+    type: string
+    description: What's the role name to use for CodeArtifact authentication?
+    required: false
+    default: no-code-artifact
+  code-artifact-auth-role-account-id:
+    type: string
+    description: What's the AWS Account ID that the role is in?
+    required: false
+  code-artifact-auth-region:
+    type: string
+    description: What region should the role use?
+    required: false
 
 
 runs:
@@ -41,11 +54,21 @@ runs:
       run: .github/actions/install_deps_uv/install-ci-tooling.ps1 ${{ env.PYTHON_VERSION }}
       shell: pwsh
 
+    - name: OIDC Auth for CodeArtifact
+      if: ${{ inputs.code-artifact-auth-role-name != 'no-code-artifact' }}
+      uses: aws-actions/configure-aws-credentials@v4.0.2
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.code-artifact-auth-role-account-id }}:role/${{ inputs.code-artifact-auth-role-name }}
+        aws-region: ${{ inputs.code-artifact-auth-region }}
+
     - name: Install Dependencies (Linux)
       if: ${{ inputs.uv-sync && runner.os == 'Linux' }}
       run: |
         sh .devcontainer/manual-setup-deps.sh ${{ env.PYTHON_VERSION }}
       shell: bash
+
+
+
 
     - name: Install Dependencies (Windows)
       if: ${{ inputs.uv-sync && runner.os == 'Windows' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
 
+      - name: Move python script that replaces private package registry information to temp folder so it doesn't get deleted
+        run: |
+          mv .github/workflows/replace_private_package_registries.py $RUNNER_TEMP
+
       - name: Install python tooling
         uses: ./.github/actions/install_deps_uv
         with:
@@ -106,7 +110,10 @@ jobs:
       - name: install new dependencies
         env:
           CODEARTIFACT_AUTH_TOKEN: 'faketoken'
+          UV_NO_CACHE: 'true'
         run: |
+          # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
+          python $RUNNER_TEMP/replace_private_package_registries.py
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them
           git add .

--- a/.github/workflows/replace_private_package_registries.py
+++ b/.github/workflows/replace_private_package_registries.py
@@ -1,0 +1,57 @@
+"""Update any project files that point to a private package registry to use public ones.
+
+Since the CI pipelines for testing these copier templates don't have access to private registries, we can't test installing from them as part of CI.
+
+Seems minimal risk, since the only problem we'd be missing is if the pyproject.toml (or similar config files) had syntax errors that would have been
+caught by pre-commit.
+"""
+
+import re
+from pathlib import Path
+
+
+def process_file(file_path: Path):
+    # Read the entire file content
+    content = file_path.read_text()
+
+    # Regex to match a block starting with [[tool.uv.index]]
+    # until the next block header (a line starting with [[) or the end of the file.
+    pattern = re.compile(r"(\[\[tool\.uv\.index\]\].*?)(?=\n\[\[|$)", re.DOTALL)
+
+    # Find all uv.index blocks.
+    blocks = pattern.findall(content)
+
+    # Check if any block contains "default = true"
+    if not any("default = true" in block for block in blocks):
+        print(f"No changes in: {file_path}")
+        return
+
+    # If at least one block contains "default = true", remove all uv.index blocks.
+    new_content = pattern.sub("", content)
+
+    # Ensure file ends with a newline before appending the new block.
+    if not new_content.endswith("\n"):
+        new_content += "\n"
+
+    # Append the new block.
+    new_block = '[[tool.uv.index]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n'
+    new_content += new_block
+
+    # Write the updated content back to the file.
+    _ = file_path.write_text(new_content)
+    print(f"Updated file: {file_path}")
+
+
+def main():
+    base_dir = Path(".")
+    # Use rglob to find all pyproject.toml files recursively.
+    for file_path in base_dir.rglob("pyproject.toml"):
+        # Check if the file is at most two levels deep.
+        # The relative path's parts count should be <= 3 (e.g. "pyproject.toml" is 1 part,
+        # "subdir/pyproject.toml" is 2 parts, and "subdir/subsubdir/pyproject.toml" is 3 parts).
+        if len(file_path.relative_to(base_dir).parts) <= 3:
+            process_file(file_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -1,5 +1,5 @@
 {% if python_package_registry is defined and python_package_registry == "AWS CodeArtifact" %}{% raw %}#!/usr/bin/env bash
-set -e
+set -ex
 
 # If none of these are set we can't possibly continue and should fail so you can fix it
 if [ -z "$AWS_PROFILE" ] && [ -z "$AWS_ACCESS_KEY_ID" ] && [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
@@ -9,14 +9,39 @@ else
     # Only regenerate the token if it doesn't exist or wasn't already set as an environmental variable (e.g. during CI or passed into a docker image build)
     if [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
         echo "Fetching CodeArtifact token"
-        # TODO: only re-login if the sso credentials have expired
-        aws sso login --profile={% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}
-        export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain {% endraw %}{{ repo_org_name }}{% raw %} --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} --region {% endraw %}{{ aws_org_home_region }}{% raw %} --query authorizationToken --output text --profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %})
+        if [ -z "$CI" ]; then
+            PROFILE_ARGS="--profile={% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}"
+        else
+            PROFILE_ARGS=""
+        fi
+
+        # Check if AWS credentials are valid by trying to retrieve the caller identity.
+        # If the ARN is not returned, assume credentials are expired or not set correctly.
+        caller_identity=$(aws sts get-caller-identity --region={% endraw %}{{ aws_org_home_region }}{% raw %} $PROFILE_ARGS --query Arn --output text 2>/dev/null || echo "")
+        if [ -z "$caller_identity" ]; then
+            if [ -n "$CI" ]; then
+                echo "Error: In CI environment, aws sso login should never be called...something is wrong with this script or your workflow...perhaps you did not OIDC Auth yet in CI?"
+                exit 1
+            fi
+            echo "SSO credentials not found or expired, logging in..."
+            aws sso login $PROFILE_ARGS
+        else
+            echo "Using existing AWS credentials: $caller_identity"
+        fi
+
+        set +x
+        export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
+            --domain {% endraw %}{{ repo_org_name }}{% raw %} \
+            --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} \
+            --region {% endraw %}{{ aws_org_home_region }}{% raw %} \
+            --query authorizationToken \
+            --output text $PROFILE_ARGS)
+        set -x
     fi
 
-    export UV_INDEX_CODE_ARTIFACT_PRIMARY_USERNAME=aws
+    set +x
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
-    export UV_INDEX_CODE_ARTIFACT_STAGING_USERNAME=aws
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    set -x
 
 fi{% endraw %}{% else %}{% raw %}# Placeholder file not being used by these copier template answers{% endraw %}{% endif %}

--- a/template/.github/actions/install_deps_uv/action.yml
+++ b/template/.github/actions/install_deps_uv/action.yml
@@ -14,6 +14,19 @@ inputs:
     description: What's the relative path to the project?
     required: false
     default: ./
+  code-artifact-auth-role-name:
+    type: string
+    description: What's the role name to use for CodeArtifact authentication?
+    required: false
+    default: no-code-artifact
+  code-artifact-auth-role-account-id:
+    type: string
+    description: What's the AWS Account ID that the role is in?
+    required: false
+  code-artifact-auth-region:
+    type: string
+    description: What region should the role use?
+    required: false
 
 
 runs:
@@ -41,11 +54,21 @@ runs:
       run: .github/actions/install_deps_uv/install-ci-tooling.ps1 ${{ env.PYTHON_VERSION }}
       shell: pwsh
 
+    - name: OIDC Auth for CodeArtifact
+      if: ${{ inputs.code-artifact-auth-role-name != 'no-code-artifact' }}
+      uses: aws-actions/configure-aws-credentials@v4.0.2
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.code-artifact-auth-role-account-id }}:role/${{ inputs.code-artifact-auth-role-name }}
+        aws-region: ${{ inputs.code-artifact-auth-region }}
+
     - name: Install Dependencies (Linux)
       if: ${{ inputs.uv-sync && runner.os == 'Linux' }}
       run: |
         sh .devcontainer/manual-setup-deps.sh ${{ env.PYTHON_VERSION }}
       shell: bash
+
+
+
 
     - name: Install Dependencies (Windows)
       if: ${{ inputs.uv-sync && runner.os == 'Windows' }}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -14,6 +14,9 @@ To create a new repository using this template:
 4. Commit the changes
 5. Rebuild your new devcontainer
 
+{% endraw %}{% if manage_github_repos %}{% raw %}## Managing your organization's GitHub repositories
+The file `src/aws_central_infrastructure/github_repos/repos.py` contains a list of repositories that are managed by this project. To add a new repository, add a new entry to the `configs` list.{% endraw %}{% endif %}{% raw %}
+
 
 
 # Development

--- a/template/src/aws_central_infrastructure/iac_management/github_oidc.py
+++ b/template/src/aws_central_infrastructure/iac_management/github_oidc.py
@@ -1,29 +1,10 @@
-from collections import defaultdict
-
 from .lib import AwsLogicalWorkload
 from .lib import GithubOidcConfig
 from .lib import WorkloadName
-from .lib import create_application_oidc_if_needed
-from .lib import create_oidc_for_single_account_workload
-from .lib.constants import CENTRAL_INFRA_GITHUB_ORG_NAME
-from .lib.constants import CENTRAL_INFRA_REPO_NAME
 
 
-def generate_all_oidc(
-    *, workloads_info: dict[WorkloadName, AwsLogicalWorkload]
-) -> dict[WorkloadName, list[GithubOidcConfig]]:
-    all_oidc: dict[WorkloadName, list[GithubOidcConfig]] = defaultdict(list)
-    create_application_oidc_if_needed(all_oidc=all_oidc, workloads_info=workloads_info)
-
-    workload_name = "identity-center"
-    identity_center_workload = workloads_info[workload_name]
-    all_oidc[workload_name].extend(
-        create_oidc_for_single_account_workload(
-            aws_account_id=identity_center_workload.prod_accounts[0].id,
-            repo_org=CENTRAL_INFRA_GITHUB_ORG_NAME,
-            repo_name=CENTRAL_INFRA_REPO_NAME,
-            role_name_suffix="identity-center",
-        )
-    )
-
-    return all_oidc
+def generate_oidc(
+    *, workloads_info: dict[WorkloadName, AwsLogicalWorkload], all_oidc: dict[WorkloadName, list[GithubOidcConfig]]
+) -> None:
+    # create OIDC here
+    pass

--- a/template/src/aws_central_infrastructure/iac_management/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/__init__.py
@@ -1,4 +1,3 @@
-from .application_oidc import create_application_oidc_if_needed
 from .github_oidc_lib import AwsAccountId
 from .github_oidc_lib import GithubOidcConfig
 from .github_oidc_lib import WorkloadName

--- a/template/src/aws_central_infrastructure/iac_management/lib/application_oidc.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/application_oidc.py
@@ -1,8 +1,17 @@
+from ephemeral_pulumi_deploy import get_aws_account_id
+from pulumi_aws.iam import GetPolicyDocumentStatementArgs
+from pulumi_aws.iam import GetPolicyDocumentStatementConditionArgs
+from pulumi_aws.iam import get_policy_document
+from pulumi_aws_native import iam
+
+from ..github_oidc import generate_oidc
 from .constants import CENTRAL_INFRA_GITHUB_ORG_NAME
+from .constants import CENTRAL_INFRA_REPO_NAME
 from .constants import CLOUD_COURIER_INFRA_REPO_NAME
 from .constants import CONFIGURE_CLOUD_COURIER
 from .github_oidc_lib import GithubOidcConfig
 from .github_oidc_lib import WorkloadName
+from .github_oidc_lib import create_oidc_for_single_account_workload
 from .github_oidc_lib import create_oidc_for_standard_workload
 from .shared_lib import AwsLogicalWorkload
 
@@ -21,3 +30,47 @@ def create_application_oidc_if_needed(
             repo_name=CLOUD_COURIER_INFRA_REPO_NAME,
         )
     )
+
+
+def generate_all_oidc(
+    *, workloads_info: dict[WorkloadName, AwsLogicalWorkload], all_oidc: dict[WorkloadName, list[GithubOidcConfig]]
+) -> None:
+    workload_name = "identity-center"
+    identity_center_workload = workloads_info[workload_name]
+    all_oidc[workload_name].extend(
+        create_oidc_for_single_account_workload(
+            aws_account_id=identity_center_workload.prod_accounts[0].id,
+            repo_org=CENTRAL_INFRA_GITHUB_ORG_NAME,
+            repo_name=CENTRAL_INFRA_REPO_NAME,
+            role_name_suffix="identity-center",
+        )
+    )
+
+    all_oidc["central-infra"].append(
+        GithubOidcConfig(
+            aws_account_id=get_aws_account_id(),
+            role_name="CoreInfraBaseAccess",
+            repo_org=CENTRAL_INFRA_GITHUB_ORG_NAME,
+            repo_name="*",
+            role_policy=iam.RolePolicyArgs(
+                policy_name="ReadFromCodeArtifact",
+                policy_document=get_policy_document(
+                    statements=[
+                        GetPolicyDocumentStatementArgs(  # TODO: DRY this up with the policy for the SSO Permission Set
+                            effect="Allow",
+                            resources=["*"],
+                            actions=["sts:GetServiceBearerToken"],
+                            conditions=[
+                                GetPolicyDocumentStatementConditionArgs(
+                                    variable="sts:AWSServiceName",
+                                    test="StringEquals",
+                                    values=["codeartifact.amazonaws.com"],
+                                )
+                            ],
+                        ),
+                    ]
+                ).json,
+            ),
+        ),
+    )
+    generate_oidc(workloads_info=workloads_info, all_oidc=all_oidc)


### PR DESCRIPTION
 ## Why is this change necessary?
CI pipelines need to access Code Artifact


 ## How does this change address the issue?
Creates a Role and allows any repo in the github org to assume it


 ## What side effects does this change have?
None


 ## How is this change tested?
In a repo that needed to install from CodeArtifact


 ## Other
Pulls in a few other misc updates from upstream template