### PR TITLE
Bugfix: no duplicate github providers

### DIFF
--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
@@ -1,6 +1,7 @@
 import logging
 
 from ..repos import create_repo_configs
+from .repo import create_github_provider
 from .repo import create_repos
 
 logger = logging.getLogger(__name__)
@@ -9,4 +10,5 @@ logger = logging.getLogger(__name__)
 def pulumi_program() -> None:
     """Execute creating the stack."""
     configs = create_repo_configs()
-    create_repos(configs)
+    provider = create_github_provider()
+    create_repos(configs=configs, provider=provider)

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -118,7 +118,7 @@ class GithubRepo(ComponentResource):
         )
 
 
-def create_repos(configs: Iterable[GithubRepoConfig] | None = None) -> None:
+def create_repos(*, configs: Iterable[GithubRepoConfig] | None = None, provider: Provider) -> None:
     # Token permissions needed: All repositories, Administration: Read & write, Environments: Read & write, Contents: read & write
     # After the initial deployment which creates the secret, go in and use the Manual Secrets permission set to update the secret with the real token, then you can create repos
     _ = secretsmanager.Secret(
@@ -136,4 +136,4 @@ def create_repos(configs: Iterable[GithubRepoConfig] | None = None) -> None:
         return
 
     for config in configs:
-        _ = GithubRepo(config=config, provider=create_github_provider())
+        _ = GithubRepo(config=config, provider=provider)


### PR DESCRIPTION
 ## Why is this change necessary?
A previous codechange introduced a problem where if there were multiple repos, then multiple duplicate providers were created...which isn't allowed


 ## How does this change address the issue?
creates a single provider in program.py and passes it where needed


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo

