### PR TITLE
Fix VPC Tagging in Central Networking

### DIFF
--- a/template/src/aws_central_infrastructure/central_networking/lib/network.py
+++ b/template/src/aws_central_infrastructure/central_networking/lib/network.py
@@ -71,10 +71,10 @@ def tag_shared_resource(  # noqa: PLR0913 # this is a lot of arguments, but they
     resource_name: str,
     resource_id: Output[str],
     parent: Resource,
-    additional_depends_on: list[Resource] | None = None,
+    depends_on: list[Resource] | None = None,
 ):
-    if additional_depends_on is None:
-        additional_depends_on = []
+    if depends_on is None:
+        depends_on = [parent]
     for account_id, provider in providers.items():
         for tag in tags:
             _ = Tag(
@@ -86,7 +86,7 @@ def tag_shared_resource(  # noqa: PLR0913 # this is a lot of arguments, but they
                     provider=provider,
                     delete_before_replace=True,
                     parent=parent,
-                    depends_on=[parent, *additional_depends_on],
+                    depends_on=depends_on,
                 ),
             )
 

--- a/template/src/aws_central_infrastructure/central_networking/lib/network.py
+++ b/template/src/aws_central_infrastructure/central_networking/lib/network.py
@@ -64,14 +64,17 @@ def create_ssm_param_in_all_accounts(  # noqa: PLR0913 # this is a lot of argume
         )
 
 
-def tag_shared_resource(
+def tag_shared_resource(  # noqa: PLR0913 # this is a lot of arguments, but they're all kwargs
     *,
     providers: dict[str, pulumi_aws.Provider],
     tags: list[TagArgs],
     resource_name: str,
     resource_id: Output[str],
     parent: Resource,
+    additional_depends_on: list[Resource] | None = None,
 ):
+    if additional_depends_on is None:
+        additional_depends_on = []
     for account_id, provider in providers.items():
         for tag in tags:
             _ = Tag(
@@ -79,7 +82,12 @@ def tag_shared_resource(
                 key=tag.key,
                 value=tag.value,
                 resource_id=resource_id,
-                opts=ResourceOptions(provider=provider, delete_before_replace=True, parent=parent, depends_on=[parent]),
+                opts=ResourceOptions(
+                    provider=provider,
+                    delete_before_replace=True,
+                    parent=parent,
+                    depends_on=[parent, *additional_depends_on],
+                ),
             )
 
 
@@ -109,21 +117,14 @@ class CentralNetworkingVpc(ComponentResource):
             append_resource_suffix(name),
             None,
         )
-        tag_name = f"{name}-central-vpc"
-        vpc_tags = [TagArgs(key="Name", value=tag_name), *common_tags_native()]
+        self.tag_name = f"{name}-central-vpc"
+        self.vpc_tags = [TagArgs(key="Name", value=self.tag_name), *common_tags_native()]
         self.vpc = ec2.Vpc(
             append_resource_suffix(name),
             cidr_block="10.0.0.0/16",
             enable_dns_hostnames=True,
-            tags=vpc_tags,
+            tags=self.vpc_tags,
             opts=ResourceOptions(parent=self),
-        )
-        tag_shared_resource(
-            providers=all_providers.all_classic_providers,
-            tags=vpc_tags,
-            resource_name=tag_name,
-            resource_id=self.vpc.vpc_id,
-            parent=self.vpc,
         )
         create_ssm_param_in_all_accounts(
             providers=all_providers.all_native_providers,
@@ -165,7 +166,7 @@ class SharedSubnet(ComponentResource):
             tags=subnet_tags,
             opts=ResourceOptions(parent=self),
         )
-        subnet_share = ram.ResourceShare(
+        self.subnet_share = ram.ResourceShare(
             append_resource_suffix(config.name),
             resource_arns=[
                 subnet.subnet_id.apply(
@@ -182,7 +183,7 @@ class SharedSubnet(ComponentResource):
             tags=subnet_tags,
             resource_name=f"{config.name}-subnet",
             resource_id=subnet.subnet_id,
-            parent=subnet_share,
+            parent=self.subnet_share,
         )
         route_table_tags = [TagArgs(key="Name", value=config.name), *common_tags_native()]
         route_table = ec2.RouteTable(
@@ -196,7 +197,7 @@ class SharedSubnet(ComponentResource):
             tags=route_table_tags,
             resource_name=f"{config.name}-route-table",
             resource_id=route_table.id,
-            parent=subnet_share,
+            parent=self.subnet_share,
         )
 
         _ = ec2.SubnetRouteTableAssociation(
@@ -237,7 +238,7 @@ class SharedSubnet(ComponentResource):
             )
         create_ssm_param_in_all_accounts(
             providers=all_providers.all_native_providers,
-            parent=subnet_share,
+            parent=self.subnet_share,
             resource_name_prefix=f"central-networking-subnet-id-{config.name}",
             param_value=subnet.subnet_id,
             param_name=f"{CENTRAL_NETWORKING_SSM_PREFIX}/subnets/{config.name}/id",

--- a/template/src/aws_central_infrastructure/central_networking/lib/program.py
+++ b/template/src/aws_central_infrastructure/central_networking/lib/program.py
@@ -38,7 +38,7 @@ def pulumi_program() -> None:
         resource_name=generic_vpc.tag_name,
         resource_id=generic_vpc.vpc.vpc_id,
         parent=generic_vpc,
-        additional_depends_on=[
+        depends_on=[
             generic_public.subnet_share
         ],  # the VPC itself isn't actually shared with the other accounts directly, it's only shared via the subnet, so need to wait for that RAM share to be created
     )

--- a/template/src/aws_central_infrastructure/central_networking/lib/program.py
+++ b/template/src/aws_central_infrastructure/central_networking/lib/program.py
@@ -7,6 +7,7 @@ from .network import AllAccountProviders
 from .network import CentralNetworkingVpc
 from .network import SharedSubnet
 from .network import SharedSubnetConfig
+from .network import tag_shared_resource
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,16 @@ def pulumi_program() -> None:
         ),
         org_arn=org_info.arn,
         all_providers=all_providers,
+    )
+    tag_shared_resource(
+        providers=all_providers.all_classic_providers,
+        tags=generic_vpc.vpc_tags,
+        resource_name=generic_vpc.tag_name,
+        resource_id=generic_vpc.vpc.vpc_id,
+        parent=generic_vpc,
+        additional_depends_on=[
+            generic_public.subnet_share
+        ],  # the VPC itself isn't actually shared with the other accounts directly, it's only shared via the subnet, so need to wait for that RAM share to be created
     )
     if CREATE_PRIVATE_SUBNET:
         _ = SharedSubnet(


### PR DESCRIPTION
 ## Why is this change necessary?
VPC tagging was happening before the VPC was RAM-shared to the other accounts


 ## How does this change address the issue?
Makes the tagging dependent on the first Subnet share, which actually triggers the VPC to be available


 ## What side effects does this change have?
Deployment works


 ## How is this change tested?
Will be tested after this merges in my AWS org
