### PR TITLE
GitHub Teams management

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -119,6 +119,11 @@ manage_github_repos:
     help: Do you want to use this repository to manage some of the other GitHub repositories through Infrastructure as Code?
     default: no
 
+initial_github_admin:
+    type: str
+    help: What is your GitHub username (to be set as the initial admin of the root Team)?
+    when: "{{ manage_github_repos }}"
+
 create_private_subnet:
     type: bool
     help: Do you want to create a private subnet with a NAT Gateway within the central networking VPC (this will incur costs...around $30/month)?

--- a/copier.yml
+++ b/copier.yml
@@ -124,6 +124,12 @@ initial_github_admin:
     help: What is your GitHub username (to be set as the initial admin of the root Team)?
     when: "{{ manage_github_repos }}"
 
+aws_organization_repo_name:
+    type: str
+    help: What is the name of the Github repository used to manage your AWS Organization?
+    when: "{{ manage_github_repos }}"
+    default: aws-organization
+
 create_private_subnet:
     type: bool
     help: Do you want to create a private subnet with a NAT Gateway within the central networking VPC (this will incur costs...around $30/month)?

--- a/template/CODEOWNERS.jinja
+++ b/template/CODEOWNERS.jinja
@@ -1,0 +1,1 @@
+{% raw %}* @{% endraw %}{{ central_infra_github_organization_name }}{% raw %}/DevSecOps{% endraw %}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -22,13 +22,10 @@ If an explicit parent is not provided in the configuration, the team will have t
 It's recommended to set the following permissions for the Organization to guide people towards doing more things via this repository instead of the Console.
 https://github.com/organizations/lab-sync/settings/member_privileges
 
-Base Permissions: Read
-
-Repository Creation: Neither
-
-Pages Creation: Neither
-
-Allow members to create teams: No{% endraw %}{% endif %}{% raw %}
+* Base Permissions: Read
+* Repository Creation: Neither
+* Pages Creation: Neither
+* Allow members to create teams: No{% endraw %}{% endif %}{% raw %}
 
 ## Allowing a git repository to publish a packgae to AWS CodeArtifact
 The file `src/aws_central_infrastructure/artifact_stores/internal_packages.py` contains a list of repositories that are allowed to publish packages to the AWS CodeArtifact registry. To enable a new repository to do so, add a new entry to the `repo_package_claims` list. This ensures that only one git repo has permission to publish that package, and there's no conflicts of two repos overwriting each other's packages.

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,6 +10,14 @@
 ## Managing your organization's GitHub repositories
 The file `src/aws_central_infrastructure/github_repos/repos.py` contains a list of repositories that are managed by this project. To add a new repository, add a new entry to the `configs` list.{% endraw %}{% endif %}{% raw %}
 
+### Initial configuration for Github organization
+It's recommended to set the following permissions for the Organization to guide people towards doing more things via this repository instead of the Console.
+https://github.com/organizations/lab-sync/settings/member_privileges
+Base Permissions: Read
+Repository Creation: Neither
+Pages Creation: Neither
+Allow members to create teams: No
+
 ## Allowing a git repository to publish a packgae to AWS CodeArtifact
 The file `src/aws_central_infrastructure/artifact_stores/internal_packages.py` contains a list of repositories that are allowed to publish packages to the AWS CodeArtifact registry. To enable a new repository to do so, add a new entry to the `repo_package_claims` list. This ensures that only one git repo has permission to publish that package, and there's no conflicts of two repos overwriting each other's packages.
 At the moment, only Python packages are supported. See https://github.com/LabAutomationAndScreening/copier-aws-central-infrastructure/issues/22 and https://github.com/LabAutomationAndScreening/copier-aws-central-infrastructure/issues/21

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,6 +10,7 @@
 ## Managing your company's GitHub Organization
 ### Repositories
 The file `src/aws_central_infrastructure/github_repos/repos.py` contains a list of repositories that are managed by this project. To add a new repository, add a new entry to the `configs` list.
+It's recommended to create a CODEOWNERS file within your repository to distinguish which Teams have the ability to approve Pull Requests---this allows many people to contribute via `write` access, but still gate with approvals.
 
 ### Teams
 The file `src/aws_central_infrastructure/github_repos/teams.py` contains a list of teams that are managed by this project. To add a new team, add a new entry to the `configs` list.

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -7,8 +7,15 @@
 
 
 # Usage{% endraw %}{% if manage_github_repos %}{% raw %}
-## Managing your organization's GitHub repositories
-The file `src/aws_central_infrastructure/github_repos/repos.py` contains a list of repositories that are managed by this project. To add a new repository, add a new entry to the `configs` list.{% endraw %}{% endif %}{% raw %}
+## Managing your company's GitHub Organization
+### Repositories
+The file `src/aws_central_infrastructure/github_repos/repos.py` contains a list of repositories that are managed by this project. To add a new repository, add a new entry to the `configs` list.
+
+### Teams
+The file `src/aws_central_infrastructure/github_repos/teams.py` contains a list of teams that are managed by this project. To add a new team, add a new entry to the `configs` list.
+Ensure to assign it appropriate permissions (typically `push`) for the repositories it needs access to.
+Teams can have a parent, from which they inherit permissions. This is useful for creating a hierarchy of teams.
+If an explicit parent is not provided in the configuration, the team will have the root `Everyone` team as its parent.
 
 ### Initial configuration for Github organization
 It's recommended to set the following permissions for the Organization to guide people towards doing more things via this repository instead of the Console.
@@ -16,7 +23,7 @@ https://github.com/organizations/lab-sync/settings/member_privileges
 Base Permissions: Read
 Repository Creation: Neither
 Pages Creation: Neither
-Allow members to create teams: No
+Allow members to create teams: No{% endraw %}{% endif %}{% raw %}
 
 ## Allowing a git repository to publish a packgae to AWS CodeArtifact
 The file `src/aws_central_infrastructure/artifact_stores/internal_packages.py` contains a list of repositories that are allowed to publish packages to the AWS CodeArtifact registry. To enable a new repository to do so, add a new entry to the `repo_package_claims` list. This ensures that only one git repo has permission to publish that package, and there's no conflicts of two repos overwriting each other's packages.

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -18,6 +18,8 @@ Ensure to assign it appropriate permissions (typically `push`...sometimes referr
 Teams can have a parent, from which they inherit permissions. This is useful for creating a hierarchy of teams.
 If an explicit parent is not provided in the configuration, the team will have the root `Everyone` team as its parent.
 
+You can grant a Team permissions for a repository even if that repository was not created using this process.
+
 ### Initial configuration for Github organization
 It's recommended to set the following permissions for the Organization to guide people towards doing more things via this repository instead of the Console.
 https://github.com/organizations/lab-sync/settings/member_privileges

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,20 +10,24 @@
 ## Managing your company's GitHub Organization
 ### Repositories
 The file `src/aws_central_infrastructure/github_repos/repos.py` contains a list of repositories that are managed by this project. To add a new repository, add a new entry to the `configs` list.
-It's recommended to create a CODEOWNERS file within your repository to distinguish which Teams have the ability to approve Pull Requests---this allows many people to contribute via `write` access, but still gate with approvals.
+It's recommended to create a CODEOWNERS file within your repository to distinguish which Teams have the ability to approve Pull Requests---this allows many people to contribute via `push` access, but still gate with approvals.
 
 ### Teams
 The file `src/aws_central_infrastructure/github_repos/teams.py` contains a list of teams that are managed by this project. To add a new team, add a new entry to the `configs` list.
-Ensure to assign it appropriate permissions (typically `push`) for the repositories it needs access to.
+Ensure to assign it appropriate permissions (typically `push`...sometimes referred to as `write` in other contexts) for the repositories it needs access to.
 Teams can have a parent, from which they inherit permissions. This is useful for creating a hierarchy of teams.
 If an explicit parent is not provided in the configuration, the team will have the root `Everyone` team as its parent.
 
 ### Initial configuration for Github organization
 It's recommended to set the following permissions for the Organization to guide people towards doing more things via this repository instead of the Console.
 https://github.com/organizations/lab-sync/settings/member_privileges
+
 Base Permissions: Read
+
 Repository Creation: Neither
+
 Pages Creation: Neither
+
 Allow members to create teams: No{% endraw %}{% endif %}{% raw %}
 
 ## Allowing a git repository to publish a packgae to AWS CodeArtifact

--- a/template/src/aws_central_infrastructure/iac_management/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/__init__.py
@@ -1,4 +1,5 @@
 from .constants import CENTRAL_INFRA_GITHUB_ORG_NAME
+from .constants import CENTRAL_INFRA_REPO_NAME
 from .github_oidc_lib import CODE_ARTIFACT_SERVICE_BEARER_STATEMENT
 from .github_oidc_lib import GITHUB_OIDC_URL
 from .github_oidc_lib import GithubOidcConfig

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/__init__.py
@@ -1,3 +1,4 @@
+from .constants import ROOT_GITHUB_ADMIN_USERNAME
 from .repo import GithubRepo
 from .repo import GithubRepoConfig
 from .repo import create_repos

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/__init__.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/__init__.py
@@ -1,3 +1,6 @@
 from .repo import GithubRepo
 from .repo import GithubRepoConfig
 from .repo import create_repos
+from .teams import GithubOrgMembers
+from .teams import GithubTeamConfig
+from .teams import RepositoryName

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
@@ -1,1 +1,2 @@
-{% raw %}ROOT_GITHUB_ADMIN_USERNAME = "{% endraw %}{{ initial_github_admin }}{% raw %}"{% endraw %}
+{% raw %}ROOT_GITHUB_ADMIN_USERNAME = "{% endraw %}{{ initial_github_admin }}{% raw %}"
+AWS_ORGANIZATION_REPO_NAME= "{% endraw %}{{ aws_organization_repo_name }}{% raw %}"{% endraw %}

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
@@ -1,2 +1,2 @@
 {% raw %}ROOT_GITHUB_ADMIN_USERNAME = "{% endraw %}{{ initial_github_admin }}{% raw %}"
-AWS_ORGANIZATION_REPO_NAME= "{% endraw %}{{ aws_organization_repo_name }}{% raw %}"{% endraw %}
+AWS_ORGANIZATION_REPO_NAME = "{% endraw %}{{ aws_organization_repo_name }}{% raw %}"{% endraw %}

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
@@ -1,0 +1,1 @@
+{% raw %}ROOT_GITHUB_ADMIN_USERNAME = "{% endraw %}{{ initial_github_admin }}{% raw %}"{% endraw %}

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
@@ -17,7 +17,8 @@ def pulumi_program() -> None:
     create_repo_configs(repo_configs)
     provider = create_github_provider()
     root_team = GithubTeamConfig(name="Everyone", description="Everyone in the organization, the root of all teams.")
+    dev_sec_ops_team_config = GithubTeamConfig(name="DevSecOps", description="DevSecOps Team", parent_team=root_team)
     team_configs: list[GithubTeamConfig] = []
     create_repos(configs=repo_configs, provider=provider)
-    org_members = define_team_configs(configs=team_configs)
+    org_members = define_team_configs(configs=team_configs, dev_sec_ops_team_config=dev_sec_ops_team_config)
     create_teams(configs=team_configs, provider=provider, org_members=org_members, root_team=root_team)

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
@@ -1,14 +1,23 @@
 import logging
 
 from ..repos import create_repo_configs
+from ..teams import define_team_configs
+from .repo import GithubRepoConfig
 from .repo import create_github_provider
 from .repo import create_repos
+from .teams import GithubTeamConfig
+from .teams import create_teams
 
 logger = logging.getLogger(__name__)
 
 
 def pulumi_program() -> None:
     """Execute creating the stack."""
-    configs = create_repo_configs()
+    repo_configs: list[GithubRepoConfig] = []
+    create_repo_configs(repo_configs)
     provider = create_github_provider()
-    create_repos(configs=configs, provider=provider)
+    root_team = GithubTeamConfig(name="Everyone", description="Everyone in the organization, the root of all teams.")
+    team_configs: list[GithubTeamConfig] = []
+    create_repos(configs=repo_configs, provider=provider)
+    org_members = define_team_configs(configs=team_configs)
+    create_teams(configs=team_configs, provider=provider, org_members=org_members, root_team=root_team)

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/teams.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/teams.py
@@ -1,0 +1,114 @@
+from typing import Literal
+
+from ephemeral_pulumi_deploy import append_resource_suffix
+from pulumi import ComponentResource
+from pulumi import ResourceOptions
+from pulumi_github import Provider
+from pulumi_github import Team
+from pulumi_github import TeamMembers
+from pulumi_github import TeamMembersMemberArgs
+from pulumi_github import TeamRepository
+from pydantic import BaseModel
+from pydantic import Field
+
+from aws_central_infrastructure.iac_management.lib import CENTRAL_INFRA_GITHUB_ORG_NAME
+from aws_central_infrastructure.iac_management.lib import CENTRAL_INFRA_REPO_NAME
+
+type RepositoryName = str
+type GithubRepositoryPermission = Literal["pull", "triage", "push", "maintain", "admin"]
+
+
+class GithubOrgMembers(BaseModel):
+    org_admins: list[str] = Field(default_factory=list)
+    everyone: list[str] = Field(default_factory=list)
+
+
+def ensure_full_repo_name(repo_name: str) -> str:
+    if "/" in repo_name:
+        return repo_name
+
+    return f"{CENTRAL_INFRA_GITHUB_ORG_NAME}/{repo_name}"
+
+
+class GithubTeamConfig(BaseModel):
+    name: str
+    description: str
+    privacy: Literal["secret", "closed"] = "closed"
+    maintainers: list[str] = Field(default_factory=list)
+    members: list[str] = Field(default_factory=list)
+    repo_permissions: dict[RepositoryName, GithubRepositoryPermission] = Field(default_factory=dict)
+
+    @property
+    def slug(self) -> str:
+        return self.name.replace(" ", "-").lower()
+
+    @property
+    def member_args(self) -> list[TeamMembersMemberArgs]:
+        # TODO: confirm that any members are not Org Admins, otherwise Pulumi says odd things can happen https://www.pulumi.com/registry/packages/github/api-docs/teammembership/
+        all_members: list[TeamMembersMemberArgs] = []
+
+        all_members.extend(
+            TeamMembersMemberArgs(username=maintainer, role="maintainer")
+            for maintainer in sorted(set(self.maintainers))
+        )
+        all_members.extend(
+            TeamMembersMemberArgs(username=member, role="member") for member in sorted(set(self.members))
+        )
+
+        return all_members
+
+
+class GithubTeam(ComponentResource):
+    def __init__(self, *, config: GithubTeamConfig, provider: Provider | None = None):
+        super().__init__("labauto:GithubTeam", append_resource_suffix(config.name), None)
+        self._config = config
+        team = Team(
+            append_resource_suffix(config.slug),
+            name=config.name,
+            description=config.description,
+            privacy=config.privacy,
+            opts=ResourceOptions(parent=self, provider=provider),
+        )
+        self.default_opts = ResourceOptions(parent=self, provider=provider, depends_on=[team])
+
+        _ = TeamMembers(
+            append_resource_suffix(config.slug),
+            team_id=team.id,
+            members=config.member_args,
+            opts=self.default_opts,
+        )
+        for repo_name, permission in config.repo_permissions.items():
+            full_repo_name = ensure_full_repo_name(repo_name)
+            _ = TeamRepository(
+                append_resource_suffix(
+                    f"{config.slug}-{full_repo_name.replace('/', '-')}",
+                    max_length=200,  # arbitrary, not sure if github actually enforces any limit...probably not
+                ),
+                team_id=team.id,
+                repository=repo_name,
+                permission=permission,
+                opts=self.default_opts,
+            )
+
+
+def create_teams(
+    *,
+    configs: list[GithubTeamConfig],
+    provider: Provider,
+    org_members: GithubOrgMembers,
+    root_team: GithubTeamConfig,
+) -> None:
+    # Additional Token permissions needed beyond repo: Organization-Members Read/Write
+    configs.insert(0, root_team)
+    root_team.maintainers.extend(org_members.org_admins)
+    root_team.members.extend(org_members.everyone)
+    for repo_name in (
+        CENTRAL_INFRA_REPO_NAME,
+        "aws-organization",  # TODO: parametrize this, don't hardcode the repo name
+    ):
+        root_team.repo_permissions[repo_name] = "push"
+
+    # TODO: confirm all team slugs are unique
+    # TODO: confirm there's no duplicate repos listed in the GithubTeamConfig repo permissions (prefer over dict so that there's no silent overriding of permissions)
+    for config in configs:
+        _ = GithubTeam(config=config, provider=provider)

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/repos.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/repos.py
@@ -1,14 +1,9 @@
-from collections.abc import Iterable
-
 from .lib import GithubRepoConfig
 
 
-def create_repo_configs() -> Iterable[GithubRepoConfig]:
+def create_repo_configs(configs: list[GithubRepoConfig]):
     """Create the configurations for the repositories.
 
     example: `configs.append(GithubRepoConfig(name="test-pulumi-repo", description="blah"))`
     """
-    configs: list[GithubRepoConfig] = []
     # Append repos to the list here
-
-    return configs

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/teams.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/teams.py
@@ -3,12 +3,15 @@ from .lib import GithubOrgMembers
 from .lib import GithubTeamConfig
 
 
-def define_team_configs(*, configs: list[GithubTeamConfig]) -> GithubOrgMembers:
+def define_team_configs(
+    *, configs: list[GithubTeamConfig], dev_sec_ops_team_config: GithubTeamConfig
+) -> GithubOrgMembers:
     """Create the configurations for the repositories.
 
     example: `configs.append(GithubTeamConfig(name="Manhattan Project Team", description="Working on something big"))`
     """
     _ = configs  # this line can be removed once the first team is appended on to configs, it just temporarily helps linting when the template is instantiated
+    _ = dev_sec_ops_team_config  # this line can be removed once any adjustments have been made to the DevSecOps team config
     org_members = GithubOrgMembers(org_admins=[ROOT_GITHUB_ADMIN_USERNAME])
     org_members.everyone.extend([])
     return org_members

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/teams.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/teams.py
@@ -1,0 +1,13 @@
+from .lib import GithubOrgMembers
+from .lib import GithubTeamConfig
+
+
+def define_team_configs(*, configs: list[GithubTeamConfig]) -> GithubOrgMembers:
+    """Create the configurations for the repositories.
+
+    example: `configs.append(GithubTeamConfig(name="Manhattan Project Team", description="Working on something big"))`
+    """
+    _ = configs  # this line can be removed once the first team is appended on to configs, it just temporarily helps linting when the template is instantiated
+    org_members = GithubOrgMembers(org_admins=[])
+    org_members.everyone.extend([])
+    return org_members

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/teams.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/teams.py
@@ -1,3 +1,4 @@
+from .lib import ROOT_GITHUB_ADMIN_USERNAME
 from .lib import GithubOrgMembers
 from .lib import GithubTeamConfig
 
@@ -8,6 +9,6 @@ def define_team_configs(*, configs: list[GithubTeamConfig]) -> GithubOrgMembers:
     example: `configs.append(GithubTeamConfig(name="Manhattan Project Team", description="Working on something big"))`
     """
     _ = configs  # this line can be removed once the first team is appended on to configs, it just temporarily helps linting when the template is instantiated
-    org_members = GithubOrgMembers(org_admins=[])
+    org_members = GithubOrgMembers(org_admins=[ROOT_GITHUB_ADMIN_USERNAME])
     org_members.everyone.extend([])
     return org_members

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -20,4 +20,5 @@ initial_iac_management_deploy_occurred: false
 identity_center_production_account_id: 023202320444
 configure_cloud_courier: false
 manage_github_repos: false
+initial_github_admin: leet-coder
 create_private_subnet: true

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -20,5 +20,4 @@ initial_iac_management_deploy_occurred: false
 identity_center_production_account_id: 023202320444
 configure_cloud_courier: false
 manage_github_repos: false
-initial_github_admin: leet-coder
 create_private_subnet: true

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -27,4 +27,5 @@ configure_cloud_courier: true
 cloud_courier_infra_repo_name: my-cloud-courier-infra
 manage_github_repos: true
 initial_github_admin: leet-coder
+aws_organization_repo_name: my-aws-organization
 create_private_subnet: false

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -26,4 +26,5 @@ identity_center_production_account_id: 123499989012
 configure_cloud_courier: true
 cloud_courier_infra_repo_name: my-cloud-courier-infra
 manage_github_repos: true
+initial_github_admin: leet-coder
 create_private_subnet: false


### PR DESCRIPTION
 ## Why is this change necessary?
Need to manage permissions


 ## How does this change address the issue?
Creates the ability for GitHub teams.


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo


 ## Other
Also add in rulesets by default for this repo and aws-organizations repo
Require codeowner approval by default for PRs