### PR TITLE
Warn, rather than error, if an AWS user is not found

### DIFF
--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -42,7 +42,7 @@ def lookup_user_id(username: Username) -> str:
             ),
             identity_store_id=ORG_INFO.identity_store_id,
         )
-    except Exception as e:
+    except Exception as e:  # the exception Pulumi throws is just Exception, it's not a more specific subclass
         if "ResourceNotFoundException: USER not found" in str(e):
             raise UserNotFoundInIdentityStoreError(username) from e
         raise

--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from typing import Any
 from typing import override
@@ -21,19 +22,31 @@ from .lib import UserInfo
 from .lib import Username
 from .lib import create_read_state_inline_policy
 
+logger = logging.getLogger(__name__)
 _all_users: dict[Username, UserAttributes] = {}
+
+
+class UserNotFoundInIdentityStoreError(ValueError):
+    def __init__(self, username: Username):
+        super().__init__(f"User {username!r} not found in the Identity Store")
 
 
 def lookup_user_id(username: Username) -> str:
     """Convert a username name into an AWS SSO User ID."""
-    return identitystore_classic.get_user(
-        alternate_identifier=identitystore_classic.GetUserAlternateIdentifierArgs(
-            unique_attribute=identitystore_classic.GetUserAlternateIdentifierUniqueAttributeArgs(
-                attribute_path="UserName", attribute_value=username
-            )
-        ),
-        identity_store_id=ORG_INFO.identity_store_id,
-    ).user_id
+    try:
+        user_result = identitystore_classic.get_user(
+            alternate_identifier=identitystore_classic.GetUserAlternateIdentifierArgs(
+                unique_attribute=identitystore_classic.GetUserAlternateIdentifierUniqueAttributeArgs(
+                    attribute_path="UserName", attribute_value=username
+                )
+            ),
+            identity_store_id=ORG_INFO.identity_store_id,
+        )
+    except Exception as e:
+        if "ResourceNotFoundException: USER not found" in str(e):
+            raise UserNotFoundInIdentityStoreError(username) from e
+        raise
+    return user_result.user_id
 
 
 class AwsSsoPermissionSet(ComponentResource):
@@ -336,11 +349,18 @@ class AwsSsoPermissionSetAccountAssignments(ComponentResource):
         user_infos = _create_unique_userinfo_list(users)
 
         for user_info in user_infos:
+            try:
+                principal_id = lookup_user_id(user_info.username)
+            except UserNotFoundInIdentityStoreError as e:
+                logger.warning(
+                    f"Skipping user {user_info.username!r} for {resource_name} permission set assignment because {e}"
+                )
+                continue
             _ = ssoadmin.AccountAssignment(
                 f"{resource_name}-{user_info.username}",
                 instance_arn=ORG_INFO.sso_instance_arn,
                 permission_set_arn=permission_set.permission_set_arn,
-                principal_id=lookup_user_id(user_info.username),
+                principal_id=principal_id,
                 principal_type="USER",
                 target_id=account_info.id,
                 target_type="AWS_ACCOUNT",


### PR DESCRIPTION
 ## Why is this change necessary?
AWS users can be in process of being created, or deleted, and the permission set assignments can get all sorts of messed up if errors occur during preview/deploy


 ## How does this change address the issue?
Logs a warning instead if a user isn't found


 ## What side effects does this change have?
You'd need to check for warnings, otherwise the code wouldn't necessarily reflect the true state


 ## How is this change tested?
Downstream repo
