### PR TITLE
Import central-infra repos into github stack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
         copier: [
           '--data-file tests/copier_data/data1.yaml',
           '--data-file tests/copier_data/data2.yaml',
+          '--data-file tests/copier_data/data3.yaml',
           ]
     runs-on: ${{ matrix.os }}
 

--- a/copier.yml
+++ b/copier.yml
@@ -125,6 +125,18 @@ initial_github_admin:
     help: What is your GitHub username (to be set as the initial admin of the root Team)?
     when: "{{ manage_github_repos }}"
 
+import_github_aws_org_repos:
+    type: bool
+    help: Do you want to start the process of importing the AWS-Organization and AWS-Central-Infrastructure repositories to be managed by this project?
+    default: no
+    when: "{{ manage_github_repos }}"
+
+finished_importing_github_aws_org_repos:
+    type: bool
+    help: Did you complete a successful deployment to main of importing the AWS-Organization and AWS-Central-Infrastructure repositories yet?
+    default: no
+    when: "{{ import_github_aws_org_repos }}"
+
 aws_organization_repo_name:
     type: str
     help: What is the name of the Github repository used to manage your AWS Organization?

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
@@ -1,2 +1,4 @@
 {% raw %}ROOT_GITHUB_ADMIN_USERNAME = "{% endraw %}{{ initial_github_admin }}{% raw %}"
-AWS_ORGANIZATION_REPO_NAME = "{% endraw %}{{ aws_organization_repo_name }}{% raw %}"{% endraw %}
+AWS_ORGANIZATION_REPO_NAME = "{% endraw %}{{ aws_organization_repo_name }}{% raw %}"
+ACTIVELY_IMPORT_AWS_ORG_REPOS = {% endraw %}{{ 'True' if import_github_aws_org_repos and not finished_importing_github_aws_org_repos else 'False' }}{% raw %}
+AWS_ORG_REPOS_SUCCESSFULLY_IMPORTED = {% endraw %}{{ 'True' if finished_importing_github_aws_org_repos else 'False' }}{% raw %}{% endraw %}

--- a/tests/copier_data/data3.yaml
+++ b/tests/copier_data/data3.yaml
@@ -29,5 +29,5 @@ manage_github_repos: true
 initial_github_admin: leet-coder
 aws_organization_repo_name: my-aws-organization
 import_github_aws_org_repos: true
-finished_importing_github_aws_org_repos: true
+finished_importing_github_aws_org_repos: false
 create_private_subnet: false


### PR DESCRIPTION
 ## Why is this change necessary?
Be able to import the existing repositories under the management of the github stack


 ## How does this change address the issue?
Adds questions around that process in the template. Adds conditionals within the github deployment code.


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo using this process

