### PR TITLE
Allow longer names for Image Builder resources

### DIFF
--- a/template/src/aws_central_infrastructure/artifact_stores/lib/image_builder.py
+++ b/template/src/aws_central_infrastructure/artifact_stores/lib/image_builder.py
@@ -109,7 +109,7 @@ class Ec2ImageBuilder(ComponentResource):
                 ],
             )
             _ = RolePolicy(
-                append_resource_suffix(f"{resource_name}-s3-read"),
+                append_resource_suffix(f"{resource_name}-s3-read", max_length=99),
                 role=ec2_builder.instance_role.role_name,  # type: ignore[reportArgumentType] # pyright somehow thinks that a role_name can be None...which cannot happen
                 policy=manual_artifacts_bucket_name.apply(
                     lambda bucket_name: get_policy_document(


### PR DESCRIPTION
 ## Why is this change necessary?
artificially low constriction


 ## How does this change address the issue?
raises limit


 ## What side effects does this change have?
none


 ## How is this change tested?
downstream repo using builder

