### PR TITLE
SSM Terminal Connect permissions

### DIFF
--- a/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
+++ b/template/src/aws_central_infrastructure/{% if initial_iac_management_deploy_occurred %}identity_center{% endif %}/lib/permissions.py
@@ -190,6 +190,7 @@ EC2_SSO_PER_SET_CONTAINER = AwsSsoPermissionSetContainer(  # based on https://aw
                     "arn:aws:ec2:*:*:instance/*",
                     "arn:aws:ssm:*:*:managed-instance/*",
                     "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession",
+                    "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell",
                 ],
                 conditions=[
                     GetPolicyDocumentStatementConditionArgs(
@@ -225,6 +226,19 @@ EC2_SSO_PER_SET_CONTAINER = AwsSsoPermissionSetContainer(  # based on https://aw
                     "ssm-guiconnect:StartConnection",
                 ],
                 resources=["*"],
+            ),
+            GetPolicyDocumentStatementArgs(
+                sid="TerminalConnect",
+                effect="Allow",
+                actions=[
+                    "ssmmessages:CreateControlChannel",
+                    "ssmmessages:CreateDataChannel",
+                    "ssmmessages:OpenControlChannel",
+                    "ssmmessages:OpenDataChannel",
+                ],
+                resources=[
+                    "*"
+                ],  # resources must be *.  TODO: figure out if there are relevant conditions that can lock it down
             ),
             GetPolicyDocumentStatementArgs(
                 sid="GlobalS3",


### PR DESCRIPTION
 ## Why is this change necessary?
Should be able to connect via terminal to EC2 instances when needed


 ## How does this change address the issue?
Adds permission to do so


 ## What side effects does this change have?
None


 ## How is this change tested?
Live in the console in a downstream repo

