### PR TITLE
Allow all branches OIDC for Preview against Production

### DIFF
--- a/template/src/aws_central_infrastructure/iac_management/lib/github_oidc_lib.py
+++ b/template/src/aws_central_infrastructure/iac_management/lib/github_oidc_lib.py
@@ -228,7 +228,6 @@ def create_oidc_for_standard_workload(
         configs.append(
             GithubOidcConfig(
                 aws_account_id=prod_account.id,
-                restrictions="ref:refs/heads/main",
                 **deploy_kwargs,
             )
         )


### PR DESCRIPTION
 ## Why is this change necessary?
A PR should be able to preview changes to Prod


 ## How does this change address the issue?
Corrects permission for OIDC


 ## What side effects does this change have?
Should work


 ## How is this change tested?
Isn't
