### PR TITLE
Add Github Repo bypass for Write Role

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.30
+_commit: v0.0.31
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing Central Infrastructure of an AWS Organization
 python_ci_versions:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,6 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this): 47c864d4
   // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): d00a54be
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,8 +31,6 @@
         "ms-vscode-remote.remote-containers@0.383.0",
         "charliermarsh.ruff@2024.54.0",
 
-
-
         // Misc file formats
         "bierner.markdown-mermaid@1.28.0",
         "samuelcolvin.jinjahtml@0.20.0",
@@ -62,5 +60,5 @@
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
   // Devcontainer context hash (do not manually edit this): 47c864d4
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 87546122
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): d00a54be
 }

--- a/.devcontainer/install-ci-tooling.sh
+++ b/.devcontainer/install-ci-tooling.sh
@@ -6,7 +6,7 @@ set -ex
 
 
 
-curl -LsSf https://astral.sh/uv/0.6.11/install.sh | sh
+curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
 uv --version
 # TODO: add uv autocompletion to the shell https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion
 

--- a/.github/actions/install_deps_uv/install-ci-tooling.ps1
+++ b/.github/actions/install_deps_uv/install-ci-tooling.ps1
@@ -3,7 +3,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-irm https://astral.sh/uv/0.6.11/install.ps1 | iex
+irm https://astral.sh/uv/0.6.17/install.ps1 | iex
 
 # Add uv to path (in github runner)
 $env:Path = "C:\Users\runneradmin\.local\bin;$env:Path"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
- ## Link to Issue or Slack thread
+ ## Link to Issue or Message thread
 
 
 

--- a/.github/workflows/hash_git_files.py
+++ b/.github/workflows/hash_git_files.py
@@ -36,7 +36,7 @@ def filter_files_for_devcontainer_context(files: list[str]) -> tuple[list[str], 
                 devcontainer_json_file_path = file
                 continue
             devcontainer_context.append(file)
-        elif file.endswith(".lock") or file == ".pre-commit-config.yaml":
+        elif file.endswith((".lock", "pnpm-lock.yaml", "hash_git_files.py")) or file == ".pre-commit-config.yaml":
             devcontainer_context.append(file)
     if devcontainer_json_file_path is None:
         raise ValueError("No devcontainer.json file found in the tracked files.")  # noqa: TRY003 # not worth a custom exception for this

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
 
   # Reformatting (should generally come before any file format or other checks, because reformatting can change things)
   - repo: https://github.com/crate-ci/typos
-    rev: a6d2f47d4902ee6df75b9392dd3f7a120fdf3619  # frozen: v1
+    rev: 15ff058881549e16b0edb975a9b0b0d0cccd612c  # frozen: v1
     hooks:
       - id: typos
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -73,6 +73,15 @@ repos:
               .*tsconfig.json|
           )$
         args: [--autofix, --no-sort-keys]
+
+  - repo: https://github.com/biomejs/pre-commit
+    rev: 748e40d32e076a6aaaf3353a2564c8fe43764f79  # frozen: v2.0.0-beta.1
+    hooks:
+      - id: biome-check
+        exclude: |
+          (?x)^(
+              .*generated/graphql.ts|
+          )$
 
   - repo: https://github.com/pre-commit/mirrors-prettier # TODO: switch to a different approach...this was archived in 2024
     rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
@@ -180,7 +189,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: d119aaff6891558b6eaf52518386871d1d267131  # frozen: v0.11.6
+    rev: e84319e627902e1b348574ecf3238dc511933dc7  # frozen: v0.11.7
     hooks:
       - id: ruff
         name: ruff-src
@@ -223,6 +232,6 @@ repos:
       - id: compute-devcontainer-context-hash
         name: compute devcontainer context hash
         entry: bash -c "python3 .github/workflows/hash_git_files.py . --for-devcontainer-config-update"
-        files: (.*.lock)|(.devcontainer/.*)|(\.pre-commit-config.yaml)
+        files: (.*.lock)|(.*pnpm-lock.yaml)|(.*hash_git_files.py)|(.devcontainer/.*)|(\.pre-commit-config.yaml)
         pass_filenames: false
         language: system

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,8 @@
+{
+  "formatter": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": false
+  }
+}

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -10,10 +10,10 @@ class ContextUpdater(ContextHook):
 
     @override
     def hook(self, context: dict[Any, Any]) -> dict[Any, Any]:
-        context["uv_version"] = "0.6.11"
-        context["pnpm_version"] = "10.8.1"
+        context["uv_version"] = "0.6.17"
+        context["pnpm_version"] = "10.10.0"
         context["pre_commit_version"] = "4.2.0"
-        context["pyright_version"] = "1.1.399"
+        context["pyright_version"] = "1.1.400"
         context["pytest_version"] = "8.3.5"
         context["pytest_randomly_version"] = "3.16.0"
         context["pytest_cov_version"] = "6.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "pytest>=8.3.5",
     "pytest-cov>=6.0.0",
     "pytest-randomly>=3.16.0",
-    "pyright[nodejs]>=1.1.399",
+    "pyright[nodejs]>=1.1.400",
     "copier>=9.6.0",
     "copier-templates-extensions>=0.3.0"
 

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -17,8 +17,7 @@
       // https://github.com/devcontainers/features/tree/main/src/node
       "version": "{% endraw %}{{ node_version }}{% raw %}",
       "pnpmVersion": "{% endraw %}{{ pnpm_version }}{% raw %}"
-    }
-{% endraw %}{% endif %}{% raw %}
+    }{% endraw %}{% endif %}{% raw %}
   },
   "customizations": {
     "vscode": {
@@ -36,7 +35,6 @@
         "ms-python.vscode-pylance@2024.9.2",
         "ms-vscode-remote.remote-containers@0.383.0",
         "charliermarsh.ruff@2024.54.0",
-
 {% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_vuejs is defined and template_uses_vuejs is sameas(true) %}{% raw %}
         // VueJS
         "vue.volar@2.2.8",
@@ -45,7 +43,6 @@
         // All javascript
         "dbaeumer.vscode-eslint@3.0.13",
 {% endraw %}{% endif %}{% raw %}
-
         // Misc file formats
         "bierner.markdown-mermaid@1.28.0",
         "samuelcolvin.jinjahtml@0.20.0",

--- a/template/.github/actions/install_deps_uv/install-ci-tooling.ps1
+++ b/template/.github/actions/install_deps_uv/install-ci-tooling.ps1
@@ -3,7 +3,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-irm https://astral.sh/uv/0.6.11/install.ps1 | iex
+irm https://astral.sh/uv/0.6.17/install.ps1 | iex
 
 # Add uv to path (in github runner)
 $env:Path = "C:\Users\runneradmin\.local\bin;$env:Path"

--- a/template/.github/pull_request_template.md
+++ b/template/.github/pull_request_template.md
@@ -1,4 +1,4 @@
- ## Link to Issue or Slack thread
+ ## Link to Issue or Message thread
 
 
 

--- a/template/.github/workflows/hash_git_files.py
+++ b/template/.github/workflows/hash_git_files.py
@@ -36,7 +36,7 @@ def filter_files_for_devcontainer_context(files: list[str]) -> tuple[list[str], 
                 devcontainer_json_file_path = file
                 continue
             devcontainer_context.append(file)
-        elif file.endswith(".lock") or file == ".pre-commit-config.yaml":
+        elif file.endswith((".lock", "pnpm-lock.yaml", "hash_git_files.py")) or file == ".pre-commit-config.yaml":
             devcontainer_context.append(file)
     if devcontainer_json_file_path is None:
         raise ValueError("No devcontainer.json file found in the tracked files.")  # noqa: TRY003 # not worth a custom exception for this

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
 
   # Reformatting (should generally come before any file format or other checks, because reformatting can change things)
   - repo: https://github.com/crate-ci/typos
-    rev: a6d2f47d4902ee6df75b9392dd3f7a120fdf3619  # frozen: v1
+    rev: 15ff058881549e16b0edb975a9b0b0d0cccd612c  # frozen: v1
     hooks:
       - id: typos
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -73,6 +73,15 @@ repos:
               .*tsconfig.json|
           )$
         args: [--autofix, --no-sort-keys]
+
+  - repo: https://github.com/biomejs/pre-commit
+    rev: 748e40d32e076a6aaaf3353a2564c8fe43764f79  # frozen: v2.0.0-beta.1
+    hooks:
+      - id: biome-check
+        exclude: |
+          (?x)^(
+              .*generated/graphql.ts|
+          )$
 
   - repo: https://github.com/pre-commit/mirrors-prettier # TODO: switch to a different approach...this was archived in 2024
     rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
@@ -180,7 +189,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: d119aaff6891558b6eaf52518386871d1d267131  # frozen: v0.11.6
+    rev: e84319e627902e1b348574ecf3238dc511933dc7  # frozen: v0.11.7
     hooks:
       - id: ruff
         name: ruff-src
@@ -223,6 +232,6 @@ repos:
       - id: compute-devcontainer-context-hash
         name: compute devcontainer context hash
         entry: bash -c "python3 .github/workflows/hash_git_files.py . --for-devcontainer-config-update"
-        files: (.*.lock)|(.devcontainer/.*)|(\.pre-commit-config.yaml)
+        files: (.*.lock)|(.*pnpm-lock.yaml)|(.*hash_git_files.py)|(.devcontainer/.*)|(\.pre-commit-config.yaml)
         pass_filenames: false
         language: system

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -9,8 +9,9 @@
 # Usage{% endraw %}{% if manage_github_repos %}{% raw %}
 ## Managing your company's GitHub Organization
 ### Repositories
-The file `src/aws_central_infrastructure/github_repos/repos.py` contains a list of repositories that are managed by this project. To add a new repository, add a new entry to the `configs` list.
-It's recommended to create a CODEOWNERS file within your repository to distinguish which Teams have the ability to approve Pull Requests---this allows many people to contribute via `push` access, but still gate with approvals.
+The file `src/aws_central_infrastructure/github_repos/repos.py` contains a list of repositories that are managed by this project. To add a new repository, add a new entry to the `configs` list. You'll also likely want to grant at least one Team some permissions to use this new repository (see section below on Teams).
+
+If you want to allow many people to contribute via `push` access, but still gate Pull Requests with approvals from a smaller subset of people, you can create a CODEOWNERS file within your repository to distinguish which Teams have the ability to approve Pull Requests.
 
 ### Teams
 The file `src/aws_central_infrastructure/github_repos/teams.py` contains a list of teams that are managed by this project. To add a new team, add a new entry to the `configs` list.

--- a/template/biome.json
+++ b/template/biome.json
@@ -1,0 +1,8 @@
+{
+  "formatter": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": false
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = ">=9.6.0" },
     { name = "copier-templates-extensions", specifier = ">=0.3.0" },
-    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.399" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.400" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
@@ -325,15 +325,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.399"
+version = "1.1.400"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/9d/d91d5f6d26b2db95476fefc772e2b9a16d54c6bd0ea6bb5c1b6d635ab8b4/pyright-1.1.399.tar.gz", hash = "sha256:439035d707a36c3d1b443aec980bc37053fbda88158eded24b8eedcf1c7b7a1b", size = 3856954 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/cb/c306618a02d0ee8aed5fb8d0fe0ecfed0dbf075f71468f03a30b5f4e1fe0/pyright-1.1.400.tar.gz", hash = "sha256:b8a3ba40481aa47ba08ffb3228e821d22f7d391f83609211335858bf05686bdb", size = 3846546 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/b5/380380c9e7a534cb1783c70c3e8ac6d1193c599650a55838d0557586796e/pyright-1.1.399-py3-none-any.whl", hash = "sha256:55f9a875ddf23c9698f24208c764465ffdfd38be6265f7faf9a176e1dc549f3b", size = 5592584 },
+    { url = "https://files.pythonhosted.org/packages/c8/a5/5d285e4932cf149c90e3c425610c5efaea005475d5f96f1bfdb452956c62/pyright-1.1.400-py3-none-any.whl", hash = "sha256:c80d04f98b5a4358ad3a35e241dbf2a408eee33a40779df365644f8054d2517e", size = 5563460 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why is this change necessary?
Sometimes there are basic repos that don't have any kind of approval or CI/CD process, so allow anyone with write to just merge PRs


 ## How does this change address the issue?
Adds bypass param and updates Readme


 ## What side effects does this change have?
None


 ## How is this change tested?
In a downstream repo


 ## Other
Pulled in Biome upstream copier update