### PR TITLE
Get github IaC token from envvar

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.51
+_commit: v0.0.51-1-gdde3c49
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing Central Infrastructure of an AWS Organization
 python_ci_versions:

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.51-1-gdde3c49
+_commit: v0.0.52
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing Central Infrastructure of an AWS Organization
 python_ci_versions:

--- a/copier.yml
+++ b/copier.yml
@@ -144,7 +144,7 @@ initial_github_admin:
 
 use_repo_secret_for_github_iac_tokens:
     type: bool
-    help: Not recommended for enterprise users, this allows much less controlled access to secrets, only do this if you're a 1-2 person team super concerned about a dollar per month of AWS SecretsManager charges. Do you want skip using AWS Secrets Manager to hold the Github deploy tokens and just add them as repository secrets?
+    help: Not recommended for enterprise users, this allows much less controlled access to secrets, only do this if you're a 1-2 person team super concerned about a dollar per month of AWS SecretsManager charges.\nDo you want skip using AWS Secrets Manager to hold the Github deploy tokens and just add them as repository secrets?
     default: no
     when: "{{ manage_github_repos }}"
 

--- a/copier.yml
+++ b/copier.yml
@@ -142,9 +142,15 @@ initial_github_admin:
     help: What is your GitHub username (to be set as the initial admin of the root Team)?
     when: "{{ manage_github_repos }}"
 
+use_repo_secret_for_github_iac_tokens:
+    type: bool
+    help: Not recommended for enterprise users, this allows much less controlled access to secrets, only do this if you're a 1-2 person team super concerned about a dollar per month of AWS SecretsManager charges. Do you want skip using AWS Secrets Manager to hold the Github deploy tokens and just add them as repository secrets?
+    default: no
+    when: "{{ manage_github_repos }}"
+
 github_tokens_created:
     type: bool
-    help: Has a merge to main already occurred that created the AWS Secrets to hold the Github API tokens and have those API tokens been manually entered into Secrets Manager?
+    help: Has a merge to main already occurred that created the AWS Secrets to hold the Github API tokens and have those API tokens been manually entered into Secrets Manager? (Or has the token been entered as a secret in the repository if you chose that route?)
     default: no
     when: "{{ manage_github_repos }}"
 

--- a/template/.github/workflows/pulumi-aws.yml
+++ b/template/.github/workflows/pulumi-aws.yml
@@ -90,7 +90,7 @@ jobs:
   pulumi:
     runs-on: ubuntu-24.04
     env:
-      GITHUB_IAC_API_TOKEN: ${{ secrets.GITHUB_IAC_API_TOKEN }} # only used in non-enterprise situations when not using full fledged Secrets Manager
+      IAC_GITHUB_API_TOKENS: ${{ secrets.IAC_GITHUB_API_TOKENS }} # only used in non-enterprise situations when not using full fledged Secrets Manager
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/constants.py.jinja
@@ -1,5 +1,6 @@
 {% raw %}ROOT_GITHUB_ADMIN_USERNAME = "{% endraw %}{{ initial_github_admin }}{% raw %}"
 GITHUB_TOKENS_CREATED = {% endraw %}{{ 'True' if github_tokens_created else 'False'}}{% raw %}
+USE_REPO_SECRET_FOR_GITHUB_IAC_TOKENS = {% endraw %}{{ 'True' if use_repo_secret_for_github_iac_tokens else 'False'}}{% raw %}
 AWS_ORGANIZATION_REPO_NAME = "{% endraw %}{{ aws_organization_repo_name }}{% raw %}"
 ACTIVELY_IMPORT_AWS_ORG_REPOS = {% endraw %}{{ 'True' if import_github_aws_org_repos and not finished_importing_github_aws_org_repos else 'False' }}{% raw %}
 AWS_ORG_REPOS_SUCCESSFULLY_IMPORTED = {% endraw %}{{ 'True' if finished_importing_github_aws_org_repos else 'False' }}{% raw %}{% endraw %}

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/create_provider.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/create_provider.py
@@ -1,0 +1,77 @@
+import os
+
+import boto3
+from ephemeral_pulumi_deploy import get_config_str
+from lab_auto_pulumi import GITHUB_DEPLOY_TOKEN_SECRET_NAME
+from lab_auto_pulumi import GITHUB_PREVIEW_TOKEN_SECRET_NAME
+from pulumi.runtime import is_dry_run
+from pulumi_github import Provider
+from pydantic import BaseModel
+from pydantic import Field
+
+from .constants import USE_REPO_SECRET_FOR_GITHUB_IAC_TOKENS
+
+# preview token permissions: all repositories, Administration:Read, Contents: Read, Environments: Read, OrgMembers: Read
+# not sure where the rest of the info went for the deploy token permissions, but also need: Actions: Read (needed for dealing with Environments)
+
+TOKENS_ENV_VAR_NAME = "IAC_GITHUB_API_TOKENS"
+
+
+class GithubOrgApiTokens(BaseModel):
+    deploy_token: str
+
+
+type GithubOrgName = str
+
+
+class IacGithubApiTokens(BaseModel):
+    org_tokens: dict[GithubOrgName, GithubOrgApiTokens] = Field(default_factory=dict[GithubOrgName, GithubOrgApiTokens])
+
+
+# example to set envvar locally: export IAC_GITHUB_API_TOKENS='{"org_tokens": {"LabAutomationAndScreening": {"deploy_token": "my-deploy-token"}}}'
+
+
+def _get_token() -> tuple[GithubOrgName, str]:
+    if USE_REPO_SECRET_FOR_GITHUB_IAC_TOKENS:
+        if TOKENS_ENV_VAR_NAME in os.environ:
+            raw_json_token_info = os.environ[TOKENS_ENV_VAR_NAME]
+            if not raw_json_token_info:
+                raise Exception(  # noqa: TRY003,TRY002 # not worth custom exception
+                    f"The environment variable {TOKENS_ENV_VAR_NAME} is set, but it is empty. Please set it to the GitHub API token."
+                )
+            tokens = IacGithubApiTokens.model_validate_json(raw_json_token_info, strict=True)
+            if len(tokens.org_tokens) != 1:
+                raise NotImplementedError(
+                    f"More than one organization is not supported yet. Found: {tokens.org_tokens.keys()}"
+                )
+            token_info = tokens.org_tokens.popitem()
+            return token_info[0], token_info[1].deploy_token
+        if is_dry_run() and "CI" not in os.environ:
+            return "", ""  # if this is just a local pulumi preview, then a 'real' token is probably not needed
+        raise Exception(  # noqa: TRY003,TRY002 # not worth custom exception
+            f"If you are running a deployment locally (which you shouldn't be doing), then it appears you forgot to set the {TOKENS_ENV_VAR_NAME} environment variable to the GitHub API token."
+        )
+    secrets_client = boto3.client("secretsmanager")
+    secrets_response = secrets_client.list_secrets(
+        Filters=[
+            {
+                "Key": "name",
+                "Values": [GITHUB_PREVIEW_TOKEN_SECRET_NAME if is_dry_run() else GITHUB_DEPLOY_TOKEN_SECRET_NAME],
+            }
+        ]
+    )
+    secrets = secrets_response["SecretList"]
+    assert len(secrets) == 1, f"expected only 1 matching secret, but found {len(secrets)}"
+    assert "ARN" in secrets[0], f"expected 'ARN' in secrets[0], but found {secrets[0].keys()}"
+    secret_id = secrets[0]["ARN"]
+    return get_config_str("github:owner"), secrets_client.get_secret_value(SecretId=secret_id)["SecretString"]
+
+
+def create_github_provider() -> Provider:
+    # Trying to use pulumi_aws GetSecretVersionResult isn't working because it still returns an Output, and Provider requires a string. Even attempting to use apply
+
+    github_org_name, token = _get_token()
+
+    return Provider(  # TODO: figure out why this isn't getting automatically picked up from the config
+        "default", token=token, owner=github_org_name
+    )

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
@@ -14,8 +14,8 @@ from .collaborators import RepositoryCollaboratorConfig
 from .collaborators import create_repository_collaborators
 from .constants import GITHUB_TOKENS_CREATED
 from .constants import USE_REPO_SECRET_FOR_GITHUB_IAC_TOKENS
+from .create_provider import create_github_provider
 from .repo import GithubRepoConfig
-from .repo import create_github_provider
 from .repo import create_repos
 from .teams import GithubTeamConfig
 from .teams import create_teams
@@ -28,7 +28,7 @@ def pulumi_program() -> None:
     repo_configs: list[GithubRepoConfig] = []
     create_repo_configs(repo_configs)
     if not USE_REPO_SECRET_FOR_GITHUB_IAC_TOKENS:
-        # Token permissions needed: All repositories, Administration: Read & write, Environments: Read & write, Contents: read & write
+        # Token permissions needed: All repositories, Administration: Read & write, Environments: Read & write, Contents: read & write.  Organization: Members Read&Write
         # After the initial deployment which creates the secret, go in and use the Manual Secrets permission set to update the secret with the real token, then you can create repos
         _ = secretsmanager.Secret(
             append_resource_suffix("github-deploy-access-token"),

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/program.py
@@ -1,10 +1,19 @@
 import logging
 
+from ephemeral_pulumi_deploy import append_resource_suffix
+from ephemeral_pulumi_deploy.utils import common_tags_native
+from lab_auto_pulumi import GITHUB_DEPLOY_TOKEN_SECRET_NAME
+from lab_auto_pulumi import GITHUB_PREVIEW_TOKEN_SECRET_NAME
+from pulumi import ResourceOptions
+from pulumi_aws_native import secretsmanager
+
 from ..collaborators import define_repository_collaborators
 from ..repos import create_repo_configs
 from ..teams import define_team_configs
 from .collaborators import RepositoryCollaboratorConfig
 from .collaborators import create_repository_collaborators
+from .constants import GITHUB_TOKENS_CREATED
+from .constants import USE_REPO_SECRET_FOR_GITHUB_IAC_TOKENS
 from .repo import GithubRepoConfig
 from .repo import create_github_provider
 from .repo import create_repos
@@ -18,6 +27,27 @@ def pulumi_program() -> None:
     """Execute creating the stack."""
     repo_configs: list[GithubRepoConfig] = []
     create_repo_configs(repo_configs)
+    if not USE_REPO_SECRET_FOR_GITHUB_IAC_TOKENS:
+        # Token permissions needed: All repositories, Administration: Read & write, Environments: Read & write, Contents: read & write
+        # After the initial deployment which creates the secret, go in and use the Manual Secrets permission set to update the secret with the real token, then you can create repos
+        _ = secretsmanager.Secret(
+            append_resource_suffix("github-deploy-access-token"),
+            name=GITHUB_DEPLOY_TOKEN_SECRET_NAME,
+            description="GitHub access token",
+            secret_string="will-need-to-be-manually-entered",  # noqa: S106 # this is not a real secret
+            tags=common_tags_native(),
+            opts=ResourceOptions(ignore_changes=["secret_string"]),
+        )
+        _ = secretsmanager.Secret(
+            append_resource_suffix("github-preview-access-token"),
+            name=GITHUB_PREVIEW_TOKEN_SECRET_NAME,
+            description="GitHub access token",
+            secret_string="will-need-to-be-manually-entered",  # noqa: S106 # this is not a real secret
+            tags=common_tags_native(),
+            opts=ResourceOptions(ignore_changes=["secret_string"]),
+        )
+    if not GITHUB_TOKENS_CREATED:
+        return
     provider = create_github_provider()
     root_team = GithubTeamConfig(name="Everyone", description="Everyone in the organization, the root of all teams.")
     dev_sec_ops_team_config = GithubTeamConfig(name="DevSecOps", description="DevSecOps Team", parent_team=root_team)

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -5,13 +5,11 @@ from typing import Self
 import boto3
 from ephemeral_pulumi_deploy import append_resource_suffix
 from ephemeral_pulumi_deploy import get_config_str
-from ephemeral_pulumi_deploy.utils import common_tags_native
 from lab_auto_pulumi import GITHUB_DEPLOY_TOKEN_SECRET_NAME
 from lab_auto_pulumi import GITHUB_PREVIEW_TOKEN_SECRET_NAME
 from pulumi import ComponentResource
 from pulumi import ResourceOptions
 from pulumi.runtime import is_dry_run
-from pulumi_aws_native import secretsmanager
 from pulumi_github import Provider
 from pulumi_github import Repository
 from pulumi_github import RepositoryEnvironment
@@ -223,25 +221,6 @@ class GithubRepo(ComponentResource):
 
 
 def create_repos(*, configs: list[GithubRepoConfig] | None = None, provider: Provider) -> None:
-    # Token permissions needed: All repositories, Administration: Read & write, Environments: Read & write, Contents: read & write
-    # After the initial deployment which creates the secret, go in and use the Manual Secrets permission set to update the secret with the real token, then you can create repos
-    _ = secretsmanager.Secret(
-        append_resource_suffix("github-deploy-access-token"),
-        name=GITHUB_DEPLOY_TOKEN_SECRET_NAME,
-        description="GitHub access token",
-        secret_string="will-need-to-be-manually-entered",  # noqa: S106 # this is not a real secret
-        tags=common_tags_native(),
-        opts=ResourceOptions(ignore_changes=["secret_string"]),
-    )
-    _ = secretsmanager.Secret(
-        append_resource_suffix("github-preview-access-token"),
-        name=GITHUB_PREVIEW_TOKEN_SECRET_NAME,
-        description="GitHub access token",
-        secret_string="will-need-to-be-manually-entered",  # noqa: S106 # this is not a real secret
-        tags=common_tags_native(),
-        opts=ResourceOptions(ignore_changes=["secret_string"]),
-    )
-
     if configs is None:
         configs = []
     if not configs:

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -42,6 +42,7 @@ class GithubRepoConfig(BaseModel):
     delete_branch_on_merge: bool = True
     has_issues: bool = True
     has_projects: bool = False
+    has_wiki: bool = False
     has_downloads: bool = False  # this should almost never be true (it's been deprecated), but it's here for help importing repos that somehow have it set to true
     allow_auto_merge: bool = True
     squash_merge_commit_title: str = "PR_TITLE"
@@ -89,6 +90,9 @@ class GithubRepo(ComponentResource):
                 has_projects=config.has_projects
                 if config.import_existing_repo_using_config is None
                 else config.import_existing_repo_using_config.has_projects,
+                has_wiki=config.has_wiki
+                if config.import_existing_repo_using_config is None
+                else config.import_existing_repo_using_config.has_wiki,
                 has_downloads=config.has_downloads
                 if config.import_existing_repo_using_config is None
                 else config.import_existing_repo_using_config.has_downloads,

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/teams.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/teams.py
@@ -15,6 +15,8 @@ from pydantic import Field
 from aws_central_infrastructure.iac_management.lib import CENTRAL_INFRA_GITHUB_ORG_NAME
 from aws_central_infrastructure.iac_management.lib import CENTRAL_INFRA_REPO_NAME
 
+from .constants import AWS_ORG_REPOS_SUCCESSFULLY_IMPORTED
+
 type RepositoryName = str
 type GithubRepositoryPermission = Literal["pull", "triage", "push", "maintain", "admin"]
 
@@ -124,11 +126,12 @@ def fully_configure_teams(
     configs.insert(0, root_team)
     root_team.maintainers.extend(org_members.org_admins)
     root_team.members.extend(org_members.everyone)
-    for repo_name in (
-        CENTRAL_INFRA_REPO_NAME,
-        "aws-organization",  # TODO: parametrize this, don't hardcode the repo name
-    ):
-        root_team.repo_permissions[repo_name] = "push"
+    if AWS_ORG_REPOS_SUCCESSFULLY_IMPORTED:
+        for repo_name in (
+            CENTRAL_INFRA_REPO_NAME,
+            "aws-organization",  # TODO: parametrize this, don't hardcode the repo name
+        ):
+            root_team.repo_permissions[repo_name] = "push"
 
 
 def create_teams(

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/repos.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/repos.py
@@ -7,3 +7,10 @@ def create_repo_configs(configs: list[GithubRepoConfig]):
     example: `configs.append(GithubRepoConfig(name="test-pulumi-repo", description="blah"))`
     """
     # Append repos to the list here
+    configs.append(
+        GithubRepoConfig(
+            name=".github",
+            description="Public information about the Organization",
+            visibility="public",
+        )
+    )

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -28,6 +28,7 @@ cloud_courier_infra_repo_name: my-cloud-courier-infra
 manage_okta: false
 manage_github_repos: true
 initial_github_admin: leet-coder
+use_repo_secret_for_github_iac_tokens: true
 github_tokens_created: true
 aws_organization_repo_name: my-aws-organization
 import_github_aws_org_repos: true

--- a/tests/copier_data/data3.yaml
+++ b/tests/copier_data/data3.yaml
@@ -30,6 +30,7 @@ okta_org_name: your-okta-org
 okta_tokens_created: true
 manage_github_repos: true
 initial_github_admin: ada-lovelace
+use_repo_secret_for_github_iac_tokens: false
 github_tokens_created: false
 aws_organization_repo_name: my-aws-organization
 import_github_aws_org_repos: true


### PR DESCRIPTION
 ## Why is this change necessary?
Want to be able to avoid incurring SecretsManager costs for hobby projects


 ## How does this change address the issue?
Adds ability to use Github repo secret for IaC deployments


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo
