### PR TITLE
Allow specifier required number of approvers for Github PR

### DIFF
--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.140
+_commit: v0.0.142
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: Managing Central Infrastructure of an AWS Organization

--- a/.config/pyrefly.toml
+++ b/.config/pyrefly.toml
@@ -22,7 +22,7 @@ project-includes = [
                     "../tests"
                   ]
 search-path = [".."]
-disable-project-excludes-heuristics = true # with this being enabled by default, pyrefly things the src is excluded because it's an editable local install
+disable-project-excludes-heuristics = true # with this being enabled by default, pyrefly thinks the src is excluded because it's an editable local install
 python-platform = "linux"
 infer-with-first-use = false # more similar to pyright. must define the empty list type when instantiated
 # "strict" enables the maximalist error set plus strict-callable-subtyping and

--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -39,6 +39,9 @@ exclude = [
 line-length = 120
 indent-width = 4
 
+# resolved relative to the cwd where ruff runs (repo root under pre-commit), so this nests the cache under .config
+cache-dir = ".config/.ruff_cache"
+
 target-version = "py313"
 
 [lint]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ This project is a Copier template used to generate other copier templates. It is
 - Comments should be used very rarely. Code should generally express its intent.
 - Never write a one-line docstring — either the name is sufficient or the behavior warrants a full explanation.
 - Don't sort or remove imports manually — pre-commit handles it.
-- Always include type hints for pyright in Python
-- Respect the pyright rule reportUnusedCallResult; assign unneeded return values to `_`
+- Always include type hints in Python
+- Respect the pyrefly unused-call-result check; assign unneeded return values to `_`
 - Prefer keyword-only parameters (unless a very clear single-argument function): use `*` in Python signatures and destructured options objects in TypeScript.
 - When disabling a linting rule with an inline directive, provide a comment at the end of the line (or on the line above for tools that don't allow extra text after an inline directive) describing the reasoning for disabling the rule.
 - Avoid telling the type checker what a type is rather than letting it prove it. This includes type assertions (`as SomeType` in TypeScript, `cast()` in Python) and variable annotations that override inference. Prefer approaches that let the type checker verify the type itself: `isinstance`/`instanceof` narrowing, restructuring code so the correct type flows naturally, or using discriminated unions. When there is genuinely no alternative, add a comment explaining why the workaround is necessary and why it is safe.
@@ -77,7 +77,7 @@ This project is a Copier template used to generate other copier templates. It is
 - ❌ Never use `uv run python -c "import ...; print(...)"` or `inspect` to introspect Python source. ✅ Read source files directly or grep for symbols — the code is on disk and can be read without running it.
 - Check .devcontainer/devcontainer.json for tooling versions (Python, Node, etc.) when reasoning about version-specific stdlib or tooling behavior.
 - For frontend tests, run commands via `pnpm` scripts from `frontend/package.json` — never invoke tools directly (not pnpm exec <tool>, npx <tool>, etc.). ✅ pnpm test-unit  ❌ pnpm vitest ... or npx vitest ...
-- For linting and type-checking, prefer `pre-commit run <hook-id>` over invoking tools directly — this matches the permission allow-list and mirrors what CI runs. Key hook IDs: `typescript-check`, `eslint`, `pyright`, `ruff`, `ruff-format`.
+- For linting and type-checking, prefer `pre-commit run <hook-id>` over invoking tools directly — this matches the permission allow-list and mirrors what CI runs. Key hook IDs: `typescript-check`, `eslint`, `pyrefly`, `ruff`, `ruff-format`.
 - Never rely on IDE diagnostics for ruff warnings — the IDE may not respect the project's ruff.toml config. Run `pre-commit run ruff -a` to get accurate results.
 - Never use `pnpm --prefix <path>` or `uv --directory <path>` to target a different directory — these flags break the permission allow-list matcher the same way chained `cd &&` commands do. Instead, rely on the working directory already being correct (the cwd persists between Bash tool calls), or issue a plain `cd <path>` as a separate prior tool call to reposition before running the command.
 - Never use backslash line continuations in shell commands — always write the full command on a single line. Backslashes break the permission allow-list matcher.

--- a/template/.config/pyrefly.toml
+++ b/template/.config/pyrefly.toml
@@ -22,7 +22,7 @@ project-includes = [
                     "../tests"
                   ]
 search-path = [".."]
-disable-project-excludes-heuristics = true # with this being enabled by default, pyrefly things the src is excluded because it's an editable local install
+disable-project-excludes-heuristics = true # with this being enabled by default, pyrefly thinks the src is excluded because it's an editable local install
 python-platform = "linux"
 infer-with-first-use = false # more similar to pyright. must define the empty list type when instantiated
 # "strict" enables the maximalist error set plus strict-callable-subtyping and

--- a/template/.config/ruff.toml
+++ b/template/.config/ruff.toml
@@ -39,6 +39,9 @@ exclude = [
 line-length = 120
 indent-width = 4
 
+# resolved relative to the cwd where ruff runs (repo root under pre-commit), so this nests the cache under .config
+cache-dir = ".config/.ruff_cache"
+
 target-version = "py312"
 
 [lint]

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -9,8 +9,8 @@ This project is a Copier template used to generate other copier templates. It is
 - Comments should be used very rarely. Code should generally express its intent.
 - Never write a one-line docstring — either the name is sufficient or the behavior warrants a full explanation.
 - Don't sort or remove imports manually — pre-commit handles it.
-- Always include type hints for pyright in Python
-- Respect the pyright rule reportUnusedCallResult; assign unneeded return values to `_`
+- Always include type hints in Python
+- Respect the pyrefly unused-call-result check; assign unneeded return values to `_`
 - Prefer keyword-only parameters (unless a very clear single-argument function): use `*` in Python signatures and destructured options objects in TypeScript.
 - When disabling a linting rule with an inline directive, provide a comment at the end of the line (or on the line above for tools that don't allow extra text after an inline directive) describing the reasoning for disabling the rule.
 - Avoid telling the type checker what a type is rather than letting it prove it. This includes type assertions (`as SomeType` in TypeScript, `cast()` in Python) and variable annotations that override inference. Prefer approaches that let the type checker verify the type itself: `isinstance`/`instanceof` narrowing, restructuring code so the correct type flows naturally, or using discriminated unions. When there is genuinely no alternative, add a comment explaining why the workaround is necessary and why it is safe.
@@ -77,7 +77,7 @@ This project is a Copier template used to generate other copier templates. It is
 - ❌ Never use `uv run python -c "import ...; print(...)"` or `inspect` to introspect Python source. ✅ Read source files directly or grep for symbols — the code is on disk and can be read without running it.
 - Check .devcontainer/devcontainer.json for tooling versions (Python, Node, etc.) when reasoning about version-specific stdlib or tooling behavior.
 - For frontend tests, run commands via `pnpm` scripts from `frontend/package.json` — never invoke tools directly (not pnpm exec <tool>, npx <tool>, etc.). ✅ pnpm test-unit  ❌ pnpm vitest ... or npx vitest ...
-- For linting and type-checking, prefer `pre-commit run <hook-id>` over invoking tools directly — this matches the permission allow-list and mirrors what CI runs. Key hook IDs: `typescript-check`, `eslint`, `pyright`, `ruff`, `ruff-format`.
+- For linting and type-checking, prefer `pre-commit run <hook-id>` over invoking tools directly — this matches the permission allow-list and mirrors what CI runs. Key hook IDs: `typescript-check`, `eslint`, `pyrefly`, `ruff`, `ruff-format`.
 - Never rely on IDE diagnostics for ruff warnings — the IDE may not respect the project's ruff.toml config. Run `pre-commit run ruff -a` to get accurate results.
 - Never use `pnpm --prefix <path>` or `uv --directory <path>` to target a different directory — these flags break the permission allow-list matcher the same way chained `cd &&` commands do. Instead, rely on the working directory already being correct (the cwd persists between Bash tool calls), or issue a plain `cd <path>` as a separate prior tool call to reposition before running the command.
 - Never use backslash line continuations in shell commands — always write the full command on a single line. Backslashes break the permission allow-list matcher.

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -71,6 +71,7 @@ class GithubRepoConfig(BaseModel):
     org_admin_rule_bypass: bool = False
     repo_write_role_rule_bypass: bool = False
     require_code_owner_review: bool = True
+    required_approving_review_count: int = 1
     allow_update_branch: bool = False
     create_repo: bool = (
         True  # set to False if the repo already exists but you just want to apply some other Pulumi to it
@@ -249,7 +250,7 @@ class GithubRepo(ComponentResource):
                         allowed_merge_methods=config.allowed_merge_methods,
                         dismiss_stale_reviews_on_push=True,
                         require_last_push_approval=True,
-                        required_approving_review_count=1,
+                        required_approving_review_count=config.required_approving_review_count,
                         require_code_owner_review=config.require_code_owner_review,
                     ),
                 ),


### PR DESCRIPTION
## Why is this change necessary?
Need to be able to dial this in


## How does this change address the issue?
Exposes it


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repo


## Other
Pull in upstream misc changes

<!--
============== WARNING ==============================================================================
File is managed by copier template: gh:LabAutomationAndScreening/copier-base-template.git
See .config/.copier-managed-files.json for details.

You are welcome to make changes to this file in your repo if they are custom to your project,
but if the change should be shared with other projects, please backport it to the template repo.
=====================================================================================================
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for the number of required approving reviews on managed repositories, defaulting to one approval.
  * Repository rules now honor the configured approval requirement.

* **Documentation**
  * Updated development guidance and tooling instructions to use the current Python type-checking workflow.

* **Chores**
  * Improved linting cache configuration and refreshed project configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->