### PR TITLE
Allow specifying require_last_push_approval and dismiss_stale_reviews_on_push for Github PR rules

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,7 +10,7 @@
 {% raw %}[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![Checked with pyright](https://microsoft.github.io/pyright/img/pyright_badge.svg)](https://microsoft.github.io/pyright/)
+[![Checked with pyrefly](https://img.shields.io/endpoint?url=https://pyrefly.org/badge.json)](https://pyrefly.org/)
 [![Actions status](https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}/actions)
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %})
 

--- a/template/src/aws_central_infrastructure/artifact_stores/lib/ssm_buckets.py
+++ b/template/src/aws_central_infrastructure/artifact_stores/lib/ssm_buckets.py
@@ -40,7 +40,7 @@ class DistributorPackagesBucket(ComponentResource):
         _ = s3.BucketPolicy(
             append_resource_suffix("distributor-packages"),
             opts=ResourceOptions(parent=self, delete_before_replace=True),
-            bucket=self.bucket.bucket_name,  # type: ignore[reportArgumentType] # pyright somehow thinks a bucket name can be Output[None], which doesn't seem possible
+            bucket=self.bucket.bucket_name,
             policy_document=self.bucket.bucket_name.apply(
                 lambda bucket_name: (
                     get_policy_document(
@@ -123,7 +123,7 @@ class SsmBucketsSsmParameters(ComponentResource):
                 ),
                 type=ssm.ParameterType.STRING,
                 name=f"{ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX}/ssm-distributor-packages-bucket-name",
-                value=distributor_packages_bucket.bucket.bucket_name,  # type: ignore[reportArgumentType] # pyright thinks somehow the bucket name could be Output[None], which doesn't seem possible
+                value=distributor_packages_bucket.bucket.bucket_name,
                 opts=ResourceOptions(
                     parent=self,
                     provider=self.providers[account.id],
@@ -138,7 +138,7 @@ class SsmBucketsSsmParameters(ComponentResource):
                 ),
                 type=ssm.ParameterType.STRING,
                 name=f"{ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX}/manual-artifacts-bucket-name",
-                value=manual_artifacts_bucket.bucket.bucket_name,  # type: ignore[reportArgumentType] # pyright thinks somehow the bucket name could be Output[None], which doesn't seem possible
+                value=manual_artifacts_bucket.bucket.bucket_name,
                 opts=ResourceOptions(
                     delete_before_replace=True,
                     provider=self.providers[account.id],

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -27,7 +27,9 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
-from aws_central_infrastructure.artifact_stores.internal_packages import create_internal_packages_configs
+from aws_central_infrastructure.artifact_stores.internal_packages import (
+    create_internal_packages_configs,
+)
 from aws_central_infrastructure.iac_management.lib import CENTRAL_INFRA_REPO_NAME
 
 from .constants import ALLOW_ADMIN_BYPASS_FOR_AWS_ORG_REPOS
@@ -71,22 +73,22 @@ class GithubRepoConfig(BaseModel):
     org_admin_rule_bypass: bool = False
     repo_write_role_rule_bypass: bool = False
     require_code_owner_review: bool = True
-    required_approving_review_count: int = 1
+    required_approving_review_count: int = 1  # note: if `require_last_push_approval` or `require_code_owner_review` are set to True, then setting this value to 0 will not completely remove the requirement for approval---those two other options can still enforce a requirement of at least 1 approval
     require_last_push_approval: bool = True
     dismiss_stale_reviews_on_push: bool = True
     allow_update_branch: bool = False
-    create_repo: bool = (
-        True  # set to False if the repo already exists but you just want to apply some other Pulumi to it
-    )
+    create_repo: bool = True  # set to False if the repo already exists but you just want to apply some other Pulumi to it
     import_existing_repo_using_config: Self | None = None
-    create_pypi_publishing_environments: bool = (
-        False  # this generally gets automatically updated based on the package claims in the Artifact Stores module
+    create_pypi_publishing_environments: bool = False  # this generally gets automatically updated based on the package claims in the Artifact Stores module
+    autolink_references: list[AutoLinkConfig] = Field(
+        default_factory=list[AutoLinkConfig]
     )
-    autolink_references: list[AutoLinkConfig] = Field(default_factory=list[AutoLinkConfig])
     topics: list[str] = Field(default_factory=list)
-    allowed_merge_methods: Sequence[Literal["merge", "squash", "rebase"]] | None = Field(
-        default=None,
-        description="When left as None, this just uses the boolean flags for allow_merge_commit etc. But it can be set to an explicit list, usually in an attempt to prevent all types of merge commits and only allow fast-forward merges ('merge' cannot be allowed as a value here in that case, typically 'rebase' is used for this field)",
+    allowed_merge_methods: Sequence[Literal["merge", "squash", "rebase"]] | None = (
+        Field(
+            default=None,
+            description="When left as None, this just uses the boolean flags for allow_merge_commit etc. But it can be set to an explicit list, usually in an attempt to prevent all types of merge commits and only allow fast-forward merges ('merge' cannot be allowed as a value here in that case, typically 'rebase' is used for this field)",
+        )
     )
     additional_protected_branches: list[str] = Field(
         default_factory=list,
@@ -167,18 +169,24 @@ class GithubRepo(ComponentResource):
                 squash_merge_commit_message=config.squash_merge_commit_message
                 if config.import_existing_repo_using_config is None
                 else config.import_existing_repo_using_config.squash_merge_commit_message,
-                auto_init=True if config.import_existing_repo_using_config is None else None,
+                auto_init=True
+                if config.import_existing_repo_using_config is None
+                else None,
                 vulnerability_alerts=config.vulnerability_alerts
                 if config.import_existing_repo_using_config is None
                 else config.import_existing_repo_using_config.vulnerability_alerts,
                 allow_update_branch=config.allow_update_branch
                 if config.import_existing_repo_using_config is None
                 else config.import_existing_repo_using_config.allow_update_branch,
-                topics=repo_topics if config.import_existing_repo_using_config is None else None,
+                topics=repo_topics
+                if config.import_existing_repo_using_config is None
+                else None,
                 opts=ResourceOptions(
                     provider=provider,
                     parent=self,
-                    import_=None if config.import_existing_repo_using_config is None else config.name,
+                    import_=None
+                    if config.import_existing_repo_using_config is None
+                    else config.name,
                 ),
             )
         if config.create_pypi_publishing_environments:
@@ -234,7 +242,9 @@ class GithubRepo(ComponentResource):
                 target="branch",
                 enforcement="active",
                 conditions=RepositoryRulesetConditionsArgs(
-                    ref_name=RepositoryRulesetConditionsRefNameArgs(includes=includes, excludes=[])
+                    ref_name=RepositoryRulesetConditionsRefNameArgs(
+                        includes=includes, excludes=[]
+                    )
                 ),
                 rules=RepositoryRulesetRulesArgs(
                     deletion=True,
@@ -256,18 +266,24 @@ class GithubRepo(ComponentResource):
                         require_code_owner_review=config.require_code_owner_review,
                     ),
                 ),
-                opts=ResourceOptions(provider=provider, parent=self, depends_on=conditional_repo_depends),
+                opts=ResourceOptions(
+                    provider=provider, parent=self, depends_on=conditional_repo_depends
+                ),
             )
 
         autolinks = global_autolinks | set(config.autolink_references)
 
         for autolink in autolinks:
             _ = RepositoryAutolinkReference(
-                append_resource_suffix(f"{config.name}-{autolink.ticket_prefix}-autolink", max_length=150),
+                append_resource_suffix(
+                    f"{config.name}-{autolink.ticket_prefix}-autolink", max_length=150
+                ),
                 repository=config.name,
                 key_prefix=autolink.ticket_prefix,
                 target_url_template=autolink.url,
-                opts=ResourceOptions(parent=self, provider=provider, depends_on=conditional_repo_depends),
+                opts=ResourceOptions(
+                    parent=self, provider=provider, depends_on=conditional_repo_depends
+                ),
             )
 
 
@@ -283,7 +299,9 @@ def create_repos(
         configs = []
     if not configs:
         return
-    resolved_autolinks = GLOBAL_AUTOLINKS if global_autolinks is None else global_autolinks
+    resolved_autolinks = (
+        GLOBAL_AUTOLINKS if global_autolinks is None else global_autolinks
+    )
     if include_aws_org_repos:
         default_imported_repo_config = (  # these are the typical default github settings, so use these when importing a repo
             GithubRepoConfig(
@@ -327,4 +345,6 @@ def create_repos(
                     config.create_pypi_publishing_environments = True
                     break
     for config in configs:
-        _ = GithubRepo(config=config, global_autolinks=resolved_autolinks, provider=provider)
+        _ = GithubRepo(
+            config=config, global_autolinks=resolved_autolinks, provider=provider
+        )

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -72,6 +72,8 @@ class GithubRepoConfig(BaseModel):
     repo_write_role_rule_bypass: bool = False
     require_code_owner_review: bool = True
     required_approving_review_count: int = 1
+    require_last_push_approval: bool = True
+    dismiss_stale_reviews_on_push: bool = True
     allow_update_branch: bool = False
     create_repo: bool = (
         True  # set to False if the repo already exists but you just want to apply some other Pulumi to it
@@ -248,8 +250,8 @@ class GithubRepo(ComponentResource):
                     ),
                     pull_request=RepositoryRulesetRulesPullRequestArgs(
                         allowed_merge_methods=config.allowed_merge_methods,
-                        dismiss_stale_reviews_on_push=True,
-                        require_last_push_approval=True,
+                        dismiss_stale_reviews_on_push=config.dismiss_stale_reviews_on_push,
+                        require_last_push_approval=config.require_last_push_approval,
                         required_approving_review_count=config.required_approving_review_count,
                         require_code_owner_review=config.require_code_owner_review,
                     ),

--- a/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
+++ b/template/src/aws_central_infrastructure/{% if manage_github_repos %}github_repos{% endif %}/lib/repo.py
@@ -27,9 +27,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
-from aws_central_infrastructure.artifact_stores.internal_packages import (
-    create_internal_packages_configs,
-)
+from aws_central_infrastructure.artifact_stores.internal_packages import create_internal_packages_configs
 from aws_central_infrastructure.iac_management.lib import CENTRAL_INFRA_REPO_NAME
 
 from .constants import ALLOW_ADMIN_BYPASS_FOR_AWS_ORG_REPOS
@@ -77,18 +75,18 @@ class GithubRepoConfig(BaseModel):
     require_last_push_approval: bool = True
     dismiss_stale_reviews_on_push: bool = True
     allow_update_branch: bool = False
-    create_repo: bool = True  # set to False if the repo already exists but you just want to apply some other Pulumi to it
-    import_existing_repo_using_config: Self | None = None
-    create_pypi_publishing_environments: bool = False  # this generally gets automatically updated based on the package claims in the Artifact Stores module
-    autolink_references: list[AutoLinkConfig] = Field(
-        default_factory=list[AutoLinkConfig]
+    create_repo: bool = (
+        True  # set to False if the repo already exists but you just want to apply some other Pulumi to it
     )
+    import_existing_repo_using_config: Self | None = None
+    create_pypi_publishing_environments: bool = (
+        False  # this generally gets automatically updated based on the package claims in the Artifact Stores module
+    )
+    autolink_references: list[AutoLinkConfig] = Field(default_factory=list[AutoLinkConfig])
     topics: list[str] = Field(default_factory=list)
-    allowed_merge_methods: Sequence[Literal["merge", "squash", "rebase"]] | None = (
-        Field(
-            default=None,
-            description="When left as None, this just uses the boolean flags for allow_merge_commit etc. But it can be set to an explicit list, usually in an attempt to prevent all types of merge commits and only allow fast-forward merges ('merge' cannot be allowed as a value here in that case, typically 'rebase' is used for this field)",
-        )
+    allowed_merge_methods: Sequence[Literal["merge", "squash", "rebase"]] | None = Field(
+        default=None,
+        description="When left as None, this just uses the boolean flags for allow_merge_commit etc. But it can be set to an explicit list, usually in an attempt to prevent all types of merge commits and only allow fast-forward merges ('merge' cannot be allowed as a value here in that case, typically 'rebase' is used for this field)",
     )
     additional_protected_branches: list[str] = Field(
         default_factory=list,
@@ -169,24 +167,18 @@ class GithubRepo(ComponentResource):
                 squash_merge_commit_message=config.squash_merge_commit_message
                 if config.import_existing_repo_using_config is None
                 else config.import_existing_repo_using_config.squash_merge_commit_message,
-                auto_init=True
-                if config.import_existing_repo_using_config is None
-                else None,
+                auto_init=True if config.import_existing_repo_using_config is None else None,
                 vulnerability_alerts=config.vulnerability_alerts
                 if config.import_existing_repo_using_config is None
                 else config.import_existing_repo_using_config.vulnerability_alerts,
                 allow_update_branch=config.allow_update_branch
                 if config.import_existing_repo_using_config is None
                 else config.import_existing_repo_using_config.allow_update_branch,
-                topics=repo_topics
-                if config.import_existing_repo_using_config is None
-                else None,
+                topics=repo_topics if config.import_existing_repo_using_config is None else None,
                 opts=ResourceOptions(
                     provider=provider,
                     parent=self,
-                    import_=None
-                    if config.import_existing_repo_using_config is None
-                    else config.name,
+                    import_=None if config.import_existing_repo_using_config is None else config.name,
                 ),
             )
         if config.create_pypi_publishing_environments:
@@ -242,9 +234,7 @@ class GithubRepo(ComponentResource):
                 target="branch",
                 enforcement="active",
                 conditions=RepositoryRulesetConditionsArgs(
-                    ref_name=RepositoryRulesetConditionsRefNameArgs(
-                        includes=includes, excludes=[]
-                    )
+                    ref_name=RepositoryRulesetConditionsRefNameArgs(includes=includes, excludes=[])
                 ),
                 rules=RepositoryRulesetRulesArgs(
                     deletion=True,
@@ -266,24 +256,18 @@ class GithubRepo(ComponentResource):
                         require_code_owner_review=config.require_code_owner_review,
                     ),
                 ),
-                opts=ResourceOptions(
-                    provider=provider, parent=self, depends_on=conditional_repo_depends
-                ),
+                opts=ResourceOptions(provider=provider, parent=self, depends_on=conditional_repo_depends),
             )
 
         autolinks = global_autolinks | set(config.autolink_references)
 
         for autolink in autolinks:
             _ = RepositoryAutolinkReference(
-                append_resource_suffix(
-                    f"{config.name}-{autolink.ticket_prefix}-autolink", max_length=150
-                ),
+                append_resource_suffix(f"{config.name}-{autolink.ticket_prefix}-autolink", max_length=150),
                 repository=config.name,
                 key_prefix=autolink.ticket_prefix,
                 target_url_template=autolink.url,
-                opts=ResourceOptions(
-                    parent=self, provider=provider, depends_on=conditional_repo_depends
-                ),
+                opts=ResourceOptions(parent=self, provider=provider, depends_on=conditional_repo_depends),
             )
 
 
@@ -299,9 +283,7 @@ def create_repos(
         configs = []
     if not configs:
         return
-    resolved_autolinks = (
-        GLOBAL_AUTOLINKS if global_autolinks is None else global_autolinks
-    )
+    resolved_autolinks = GLOBAL_AUTOLINKS if global_autolinks is None else global_autolinks
     if include_aws_org_repos:
         default_imported_repo_config = (  # these are the typical default github settings, so use these when importing a repo
             GithubRepoConfig(
@@ -345,6 +327,4 @@ def create_repos(
                     config.create_pypi_publishing_environments = True
                     break
     for config in configs:
-        _ = GithubRepo(
-            config=config, global_autolinks=resolved_autolinks, provider=provider
-        )
+        _ = GithubRepo(config=config, global_autolinks=resolved_autolinks, provider=provider)


### PR DESCRIPTION
## Why is this change necessary?
Apparently setting the required review count to 0 isn't enough


## How does this change address the issue?
Exposes more



<!--
============== WARNING ==============================================================================
File is managed by copier template: gh:LabAutomationAndScreening/copier-base-template.git
See .config/.copier-managed-files.json for details.

You are welcome to make changes to this file in your repo if they are custom to your project,
but if the change should be shared with other projects, please backport it to the template repo.
=====================================================================================================
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable pull-request review requirements for managed repositories, including approval counts, approval of the latest push, and dismissal of stale reviews.
* **Bug Fixes**
  * Improved infrastructure resource wiring for artifact store bucket references to avoid suppressed type-checking issues.
* **Documentation**
  * Updated the quality badge to indicate checks are performed with pyrefly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->